### PR TITLE
fix: MAC/変換ツール.commandの相対パス問題を修正 (Issue #56)

### DIFF
--- a/MAC/変換ツール.command
+++ b/MAC/変換ツール.command
@@ -96,7 +96,7 @@ if [ $VENV_CREATED -eq 1 ]; then
     echo -e "${BLUE}📚 新規仮想環境に依存関係をインストール中...${NC}"
     echo -e "${BLUE}⏳ パッケージをインストール中... (しばらくお待ちください)${NC}"
     
-    if $PYTHON_CMD -m pip install -e ".[dev]" --quiet; then
+    if $PYTHON_CMD -m pip install -e "../[dev]" --quiet; then
         echo -e "${GREEN}✅ 依存関係のインストールが完了しました${NC}"
     else
         echo -e "${RED}❌ エラー: 依存関係のインストールに失敗しました${NC}"
@@ -116,7 +116,7 @@ else
         echo -e "${YELLOW}📚 必要なライブラリが不足しています。自動でインストールします...${NC}"
         echo -e "${BLUE}⏳ パッケージをインストール中... (しばらくお待ちください)${NC}"
         
-        if $PYTHON_CMD -m pip install -e ".[dev]" --quiet; then
+        if $PYTHON_CMD -m pip install -e "../[dev]" --quiet; then
             echo -e "${GREEN}✅ 依存関係のインストールが完了しました${NC}"
         else
             echo -e "${RED}❌ エラー: 依存関係のインストールに失敗しました${NC}"


### PR DESCRIPTION
## 概要
macOS版の変換ツールでpip installが失敗する問題を修正しました。

## 問題の詳細
MAC/変換ツール.commandで以下のエラーが発生していました：

```
ERROR: file:///Users/.../Kumihan-Formatter/MAC does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```

## 根本原因
1. 変換ツール.commandはMACディレクトリ内で実行される
2. 相対パス `".[dev]"` がMACディレクトリを基準に解釈される  
3. MACディレクトリには`pyproject.toml`が存在しないためエラーになる

## 修正内容
MAC/変換ツール.commandの2箇所を修正：
- 99行目: `pip install -e ".[dev]"` → `pip install -e "../[dev]"`
- 119行目: `pip install -e ".[dev]"` → `pip install -e "../[dev]"`

これでWindows版と同じ正しい相対パス指定に統一されました。

## 影響範囲
- macOSユーザーが変換ツールを正常に実行できるようになります
- Windows版に影響はありません（既に正しく実装済み）

## テスト
- [x] 構文チェック（`bash -n`）でエラーなし
- [ ] macOSでの実際の動作確認（ユーザー環境で要確認）

## 関連Issue
Fixes #56

🤖 Generated with [Claude Code](https://claude.ai/code)