### PR TITLE
fix: MAC/サンプル実行.commandの相対パス問題を修正 (Issue #58)

### DIFF
--- a/MAC/サンプル実行.command
+++ b/MAC/サンプル実行.command
@@ -28,7 +28,7 @@ echo "=========================================="
 echo ""
 
 # Check if setup has been completed
-if [ ! -d ".venv" ]; then
+if [ ! -d "../.venv" ]; then
     echo -e "${YELLOW}[WARNING] Setup not completed yet!${NC}"
     echo ""
     echo "Please run the setup first:"


### PR DESCRIPTION
## 概要
macOS版のサンプル実行で仮想環境が見つからない問題を修正しました。

## 問題の詳細
`MAC/サンプル実行.command`で以下のエラーが発生していました：

```
[WARNING] Setup not completed yet\!
```

## 根本原因
1. サンプル実行.commandはMACディレクトリ内で実行される
2. 仮想環境チェックで `.venv` を探していた（MACディレクトリ基準）
3. 実際の仮想環境は `../.venv`（rootディレクトリ）に存在

## 修正内容
MAC/サンプル実行.commandの31行目を修正：
```bash
# 修正前
if [ \! -d ".venv" ]; then

# 修正後  
if [ \! -d "../.venv" ]; then
```

これでWindows版と同じ正しい相対パス指定に統一されました。

## 影響範囲
- macOSユーザーがサンプル実行を正常に使用できるようになります
- Windows版に影響はありません（既に正しく実装済み）

## テスト
- [x] 構文チェック（`bash -n`）でエラーなし
- [ ] macOSでの実際の動作確認（ユーザー環境で要確認）

## 関連Issue
Fixes #58

🤖 Generated with [Claude Code](https://claude.ai/code)