### PR TITLE
feat: ZIP配布物から開発用ファイルを自動除外する機能を実装

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,83 @@
+# 配布物から除外するファイル・ディレクトリのリスト
+# このファイルは zip_dist コマンドで使用されます
+
+# 開発関連
+dev/
+.venv/
+venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+.eggs/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.mypy_cache/
+.ruff_cache/
+
+# ビルド関連
+build/
+dist/
+*.egg
+
+# IDE・エディタ設定
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.project
+.pydevproject
+.settings/
+
+# Git関連
+.git/
+.gitignore
+.gitattributes
+
+# Claude設定（重要：配布物からは除外）
+.claude/
+CLAUDE.md
+
+# CI/CD
+.github/
+
+# ドキュメント（開発者向け）
+CONTRIBUTING.md
+docs/dev/
+
+# テスト関連
+test_*/
+*_test/
+tests/
+examples/test_*.txt
+
+# OS固有
+.DS_Store
+Thumbs.db
+desktop.ini
+.Spotlight-V100
+.Trashes
+
+# その他の開発ファイル
+.env
+.env.*
+*.log
+*.bak
+*.tmp
+*.temp
+.bumpversion.cfg
+Makefile
+pyproject.toml
+poetry.lock
+requirements-dev.txt
+.pre-commit-config.yaml
+
+# 一時ファイル
+*_preview/
+temp_*/
+tmp_*/

--- a/.github/workflows/doc-consistency-check.yml
+++ b/.github/workflows/doc-consistency-check.yml
@@ -8,7 +8,10 @@ on:
       - 'docs/**/*.md'
       - 'pyproject.toml'
       - 'kumihan_formatter/__init__.py'
+      - 'kumihan_formatter/**/*.py'
       - 'examples/**'
+      - '.distignore'
+      - 'dev/tools/**/*.py'
   pull_request:
     branches: [ main ]
     paths:
@@ -16,7 +19,10 @@ on:
       - 'docs/**/*.md'
       - 'pyproject.toml'
       - 'kumihan_formatter/__init__.py'
+      - 'kumihan_formatter/**/*.py'
       - 'examples/**'
+      - '.distignore'
+      - 'dev/tools/**/*.py'
 
 jobs:
   doc-consistency-check:
@@ -33,6 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install -e .
     
     - name: Run documentation consistency check
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,41 @@ python -m pytest dev/tests/test_syntax_validation.py -v
 
 ---
 
+## 📦 配布管理
+
+### .distignore ファイル
+
+`zip_dist`コマンドは、`.distignore`ファイルを使用して配布物から開発用ファイルを自動除外します。
+
+#### 仕組み
+- プロジェクトルートの`.distignore`ファイルに除外パターンを記述
+- `zip_dist`コマンド実行時に自動的に読み込まれる
+- fnmatchパターンマッチングを使用（`*.pyc`、`dev/`など）
+
+#### 除外されるファイル（主要なもの）
+- 開発関連: `dev/`、`__pycache__/`、`*.pyc`、`.venv/`
+- ビルド関連: `build/`、`dist/`、`*.egg-info/`
+- IDE設定: `.vscode/`、`.idea/`
+- Git関連: `.git/`、`.gitignore`
+- Claude設定: `.claude/`、`CLAUDE.md`
+- CI/CD: `.github/`
+- テスト関連: `test_*/`、`tests/`
+- その他: `.env`、`*.log`、`pyproject.toml`など
+
+#### 使用例
+```bash
+# 配布用ZIPを作成（開発ファイルは自動除外）
+python -m kumihan_formatter.cli zip-dist . -o dist_output
+
+# 除外ファイル数の確認
+# 例: 「66個のファイルをコピー、3859個のファイルを除外」
+```
+
+#### カスタマイズ
+`.distignore`ファイルを編集して、プロジェクト固有の除外ルールを追加できます。
+
+---
+
 ## 🔮 拡張フック（今後検討）
 
 * テーマ / フォント / レイアウト切替（JSON スキーマ）

--- a/dev/tests/test_distignore.py
+++ b/dev/tests/test_distignore.py
@@ -1,0 +1,136 @@
+"""
+.distignore機能のテスト
+"""
+
+import pytest
+import tempfile
+import shutil
+from pathlib import Path
+from kumihan_formatter.cli import load_distignore_patterns, should_exclude
+
+
+class TestDistignore:
+    """配布除外機能のテストクラス"""
+    
+    def test_load_distignore_patterns(self, tmp_path):
+        """除外パターンの読み込みテスト"""
+        # .distignoreファイルを作成
+        distignore_content = """# コメント行
+dev/
+*.pyc
+__pycache__/
+.git/
+
+# 空行とコメント
+*.log
+test_*/
+"""
+        distignore_path = tmp_path / ".distignore"
+        distignore_path.write_text(distignore_content)
+        
+        # 現在のディレクトリを一時的に変更
+        import os
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            patterns = load_distignore_patterns()
+            
+            # 期待されるパターンのみが読み込まれていることを確認
+            expected_patterns = ["dev/", "*.pyc", "__pycache__/", ".git/", "*.log", "test_*/"]
+            assert patterns == expected_patterns
+            
+        finally:
+            os.chdir(original_cwd)
+    
+    def test_should_exclude_directory_patterns(self, tmp_path):
+        """ディレクトリパターンの除外テスト"""
+        patterns = ["dev/", "__pycache__/", "test_*/"]
+        base_path = tmp_path
+        
+        # テスト用のパスを作成
+        test_cases = [
+            (base_path / "dev", True),  # devディレクトリ自体
+            (base_path / "dev" / "test.py", True),  # dev配下のファイル
+            (base_path / "dev" / "tools" / "script.py", True),  # dev配下の深いファイル
+            (base_path / "__pycache__" / "module.pyc", True),  # __pycache__配下
+            (base_path / "test_module", True),  # test_で始まるディレクトリ
+            (base_path / "test_data" / "file.txt", True),  # test_で始まるディレクトリ配下
+            (base_path / "src" / "main.py", False),  # 除外対象外
+            (base_path / "development.txt", False),  # devを含むが除外対象外
+        ]
+        
+        for path, expected in test_cases:
+            # ディレクトリの場合は作成
+            if expected and "." not in path.name:
+                path.mkdir(parents=True, exist_ok=True)
+            
+            result = should_exclude(path, patterns, base_path)
+            assert result == expected, f"Path {path} should {'be excluded' if expected else 'not be excluded'}"
+    
+    def test_should_exclude_file_patterns(self, tmp_path):
+        """ファイルパターンの除外テスト"""
+        patterns = ["*.pyc", "*.log", ".DS_Store", "CLAUDE.md"]
+        base_path = tmp_path
+        
+        test_cases = [
+            (base_path / "module.pyc", True),  # .pycファイル
+            (base_path / "src" / "cache.pyc", True),  # 深い階層の.pyc
+            (base_path / "error.log", True),  # .logファイル
+            (base_path / ".DS_Store", True),  # 完全一致
+            (base_path / "docs" / ".DS_Store", True),  # 深い階層での完全一致
+            (base_path / "CLAUDE.md", True),  # CLAUDE.md
+            (base_path / "README.md", False),  # 除外対象外
+            (base_path / "main.py", False),  # 除外対象外
+        ]
+        
+        for path, expected in test_cases:
+            result = should_exclude(path, patterns, base_path)
+            assert result == expected, f"Path {path} should {'be excluded' if expected else 'not be excluded'}"
+    
+    def test_should_exclude_complex_patterns(self, tmp_path):
+        """複雑なパターンの除外テスト"""
+        patterns = [
+            "build/",
+            "dist/",
+            "*.egg-info/",
+            ".venv/",
+            "venv/",
+            "*.tmp",
+            "*_preview/",
+            ".github/",
+        ]
+        base_path = tmp_path
+        
+        test_cases = [
+            (base_path / "build" / "lib" / "module.py", True),
+            (base_path / "dist" / "package.zip", True),
+            (base_path / "kumihan_formatter.egg-info" / "PKG-INFO", True),
+            (base_path / ".venv" / "bin" / "python", True),
+            (base_path / "venv" / "lib" / "site-packages", True),
+            (base_path / "temp.tmp", True),
+            (base_path / "data" / "cache.tmp", True),
+            (base_path / "output_preview" / "index.html", True),
+            (base_path / ".github" / "workflows" / "test.yml", True),
+            (base_path / "src" / "builder.py", False),  # buildを含むが除外対象外
+            (base_path / "vendor" / "lib.js", False),  # venvを含むが除外対象外
+        ]
+        
+        for path, expected in test_cases:
+            result = should_exclude(path, patterns, base_path)
+            assert result == expected, f"Path {path} should {'be excluded' if expected else 'not be excluded'}"
+    
+    def test_empty_distignore(self):
+        """空の除外パターンでのテスト"""
+        patterns = []
+        base_path = Path("/test")
+        
+        # 全てのファイルが含まれるべき
+        test_paths = [
+            base_path / "file.py",
+            base_path / "dev" / "test.py",
+            base_path / ".git" / "config",
+            base_path / "__pycache__" / "module.pyc",
+        ]
+        
+        for path in test_paths:
+            assert not should_exclude(path, patterns, base_path), f"Path {path} should not be excluded with empty patterns"


### PR DESCRIPTION
## 概要
`zip_dist`コマンドで配布用ZIPを作成する際、開発用ファイルを自動的に除外する機能を実装しました。

## 背景
Issue #110 でのmainブランチ配布方針に基づき、配布物に開発用ツールが混入しない仕組みが必要でした。

## 実装内容
### 1. `.distignore`ファイルの追加
- fnmatchパターンで除外ファイルを定義
- 59個の除外パターンを設定（dev/, __pycache__/, *.pyc, .venv/, CLAUDE.md等）

### 2. `zip_dist`コマンドの改良
- `.distignore`ファイルの自動読み込み機能
- パターンマッチングによる除外処理
- 除外ファイル数の表示機能

### 3. テストコードの追加
- `dev/tests/test_distignore.py`で包括的なテスト
- パターン読み込み、ディレクトリ除外、ファイル除外、複雑なパターンのテスト

## 動作確認
```
# 実行結果
66個のファイルをコピー
3859個のファイルを除外
```

開発用ファイル（__pycache__, .pyc, dev/, .venv/, CLAUDE.md等）が確実に除外されることを確認しました。

## テスト
```bash
python -m pytest dev/tests/test_distignore.py -v
# 5 passed in 0.13s
```

🤖 Generated with [Claude Code](https://claude.ai/code)