### PR TITLE
fix: トグル機能メッセージの修正

### DIFF
--- a/kumihan_formatter/cli_original.py
+++ b/kumihan_formatter/cli_original.py
@@ -63,7 +63,7 @@ def _handle_sample_generation(output: str, sample_output: str, with_source_toggl
     
     use_source_toggle = with_source_toggle
     if not with_source_toggle:
-        console.print("\n[cyan][ヒント] 記法と結果を並べて表示する機能があります[/cyan]")
+        console.print("\n[cyan][ヒント] 記法と結果を切り替えて表示する機能があります[/cyan]")
         console.print("[dim]   改行処理などの動作を実際に確認しながら記法を学習できます[/dim]")
         response = console.input("[yellow]この機能を使用しますか？ (Y/n): [/yellow]")
         use_source_toggle = response.lower() in ['y', 'yes', '']
@@ -441,7 +441,7 @@ def convert(input_file, output, no_preview, watch, config, generate_test, test_o
         
         if not with_source_toggle:
             # すべてのファイルでYes/No確認
-            console.print("\n[cyan][ヒント] 記法と結果を並べて表示する機能があります[/cyan]")
+            console.print("\n[cyan][ヒント] 記法と結果を切り替えて表示する機能があります[/cyan]")
             console.print("[dim]   改行処理などの動作を実際に確認しながら記法を学習できます[/dim]")
             response = console.input("[yellow]この機能を使用しますか？ (Y/n): [/yellow]")
             use_source_toggle = response.lower() in ['y', 'yes', '']

--- a/kumihan_formatter/ui/console_ui.py
+++ b/kumihan_formatter/ui/console_ui.py
@@ -200,7 +200,7 @@ class ConsoleUI:
     
     def confirm_source_toggle(self) -> bool:
         """Confirm source toggle feature usage"""
-        self.hint("記法と結果を並べて表示する機能があります", 
+        self.hint("記法と結果を切り替えて表示する機能があります", 
                  "改行処理などの動作を実際に確認しながら記法を学習できます")
         response = self.input("[yellow]この機能を使用しますか？ (Y/n): [/yellow]")
         return response.lower() in ['y', 'yes', '']


### PR DESCRIPTION
## 概要
記法トグル機能のメッセージを実際の動作に合わせて修正しました。

## 修正内容
**Before**: 「記法と結果を並べて表示する機能があります」
**After**: 「記法と結果を切り替えて表示する機能があります」

## 修正理由
- トグル機能は実際には**切り替え**表示であり、「並べて表示」は機能の実態と異なる
- ユーザーに誤解を与える可能性がある不正確な表現を修正

## 修正箇所
- `kumihan_formatter/ui/console_ui.py` - `confirm_source_toggle()` メソッド
- `kumihan_formatter/cli_original.py` - 2箇所のヒントメッセージ

## テスト
- [x] メッセージ表示の確認
- [x] 機能動作の確認
- [x] 他の関連メッセージの整合性確認

🤖 Generated with [Claude Code](https://claude.ai/code)