### PR TITLE
fix: GitHub Actions deprecated versionsを修正

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       
@@ -29,12 +29,13 @@ jobs:
           pytest --cov=kumihan_formatter --cov-report=xml --cov-report=term-missing dev/tests/
       
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
       
       - name: Coverage comment
         uses: py-cov-action/python-coverage-comment-action@v3
@@ -49,7 +50,7 @@ jobs:
           coverage-badge -o coverage.svg
       
       - name: Upload coverage badge
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-badge
           path: coverage.svg

--- a/.github/workflows/doc-consistency-check.yml
+++ b/.github/workflows/doc-consistency-check.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     


### PR DESCRIPTION
## 概要
GitHub Actionsで発生していた deprecated actions の警告・エラーを修正しました。

## 🔧 修正内容

### バージョン更新
- `actions/setup-python@v4` → `@v5`
- `codecov/codecov-action@v3` → `@v4` 
- `actions/upload-artifact@v3` → `@v4`

### 設定改善
- codecov-actionに`CODECOV_TOKEN`を追加（v4で推奨）

## 📋 修正対象ファイル
- `.github/workflows/coverage.yml`
- `.github/workflows/doc-consistency-check.yml`

## ❌ 修正前の問題
```
This request has been automatically failed because it uses a 
deprecated version of `actions/upload-artifact: v3`
```

## ✅ 修正後の期待結果
- CI/CDワークフローの正常実行
- deprecated警告の解消
- カバレッジレポートの正常生成

## 🧪 テスト
- [x] GitHub Actions構文チェック
- [x] 既存ワークフローとの整合性確認

このPRマージ後、GitHub Actionsの失敗通知が解消されるはずです。

🤖 Generated with [Claude Code](https://claude.ai/code)