### PR TITLE
fix: テストファイルのimportエラーを修正

### DIFF
--- a/dev/tests/test_distignore.py
+++ b/dev/tests/test_distignore.py
@@ -6,7 +6,7 @@ import pytest
 import tempfile
 import shutil
 from pathlib import Path
-from kumihan_formatter.cli import load_distignore_patterns, should_exclude
+from kumihan_formatter.commands.zip_dist import load_distignore_patterns, should_exclude
 
 
 class TestDistignore:

--- a/dev/tests/test_sample_generation.py
+++ b/dev/tests/test_sample_generation.py
@@ -3,7 +3,7 @@
 import shutil
 from pathlib import Path
 import pytest
-from kumihan_formatter.cli import generate_sample
+from kumihan_formatter.commands.sample import generate_sample
 from kumihan_formatter.sample_content import SHOWCASE_SAMPLE, SAMPLE_IMAGES
 
 


### PR DESCRIPTION
## 概要
Coverage Reportで発生していたテストファイルのimportエラーを修正しました。

## 🐛 問題
リファクタリング後に古いimportパスが残っており、以下のエラーが発生：
```
ImportError: cannot import name 'load_distignore_patterns' from 'kumihan_formatter.cli'
ImportError: cannot import name 'generate_sample' from 'kumihan_formatter.cli'
```

## 🔧 修正内容

### dev/tests/test_distignore.py
```python
# Before
from kumihan_formatter.cli import load_distignore_patterns, should_exclude

# After  
from kumihan_formatter.commands.zip_dist import load_distignore_patterns, should_exclude
```

### dev/tests/test_sample_generation.py
```python
# Before
from kumihan_formatter.cli import generate_sample

# After
from kumihan_formatter.commands.sample import generate_sample
```

## ✅ 修正後の効果
- テスト収集エラーの解消
- Coverage Reportの正常実行
- CI/CDパイプラインの安定化

## 🧪 テスト
- [x] importエラーの解消確認
- [x] 新しいモジュール構造との整合性確認

この修正でCoverage Reportが正常に動作するはずです。

🤖 Generated with [Claude Code](https://claude.ai/code)