### PR TITLE
fix: 枠線ブロック内での改行処理を改善

### DIFF
--- a/kumihan_formatter/core/html_renderer.py
+++ b/kumihan_formatter/core/html_renderer.py
@@ -238,7 +238,7 @@ class HTMLRenderer:
         if content is None:
             return ''
         elif isinstance(content, str):
-            return escape(content)
+            return self._process_text_content(content)
         elif isinstance(content, Node):
             # Handle single Node objects
             return self._render_node_with_depth(content, depth + 1)
@@ -248,12 +248,12 @@ class HTMLRenderer:
                 if isinstance(item, Node):
                     parts.append(self._render_node_with_depth(item, depth + 1))
                 elif isinstance(item, str):
-                    parts.append(escape(item))
+                    parts.append(self._process_text_content(item))
                 else:
-                    parts.append(escape(str(item)))
+                    parts.append(self._process_text_content(str(item)))
             return ''.join(parts)
         else:
-            return escape(str(content))
+            return self._process_text_content(str(content))
     
     def _render_node_with_depth(self, node: Node, depth: int = 0) -> str:
         """Render a single node with depth tracking"""
@@ -282,6 +282,25 @@ class HTMLRenderer:
             return f'<{tag} {attributes}>{content}</{tag}>'
         else:
             return f'<{tag}>{content}</{tag}>'
+    
+    def _process_text_content(self, text: str) -> str:
+        """
+        Process text content, converting newlines to <br> tags
+        
+        Args:
+            text: Raw text content
+        
+        Returns:
+            str: Processed HTML with proper line breaks
+        """
+        # Escape HTML entities first
+        escaped_text = escape(text)
+        
+        # Convert newlines to <br> tags
+        # Use regex to handle various line ending types
+        processed_text = re.sub(r'\r?\n', '<br>', escaped_text)
+        
+        return processed_text
     
     def _render_attributes(self, attributes: Dict[str, Any]) -> str:
         """Render HTML attributes"""
@@ -365,7 +384,7 @@ class CompoundElementRenderer:
         sorted_keywords = self._sort_by_nesting_order(keywords)
         
         # Build nested HTML from inner to outer
-        current_html = escape(content)
+        current_html = self.html_renderer._process_text_content(content)
         
         for keyword in reversed(sorted_keywords):
             current_html = self._wrap_with_keyword(current_html, keyword, attributes)


### PR DESCRIPTION
## Summary

Issue #147 で報告された、枠線ブロック内の改行が適切に処理されない問題を修正しました。

ブロック内のテキストで改行文字が `<br>` タグに変換されるようになり、構造化されたデータ（CoC6thスキルロールの項目など）が直感的に表示されるようになります。

## 修正内容

### 🔧 コア修正
- **HTMLRenderer._render_content**: 文字列処理を新しい `_process_text_content` メソッドに変更
- **HTMLRenderer._process_text_content**: 新規メソッド追加
  - 改行文字（`\n`, `\r\n`）を `<br>` タグに変換
  - HTMLエスケープ処理も統合
- **CompoundElementRenderer**: 複合要素でも同様の処理を適用

### 📋 解決した問題

**修正前（Issue #147）:**
```
対象: ［調査対象・場所］ 難易度: ［通常/困難/極困難］ 成功: ［発見する情報・アイテム］ 失敗: ［見つからない/時間浪費］
```

**修正後:**
```
対象: ［調査対象・場所］
難易度: ［通常/困難/極困難］
成功: ［発見する情報・アイテム］
失敗: ［見つからない/時間浪費］
```

### 🎯 影響範囲

- ✅ **枠線ブロック内**: 改行が `<br>` タグに変換
- ✅ **ハイライトブロック内**: 改行が `<br>` タグに変換  
- ✅ **複合ブロック内**: 改行が `<br>` タグに変換
- ✅ **折りたたみブロック内**: 改行が `<br>` タグに変換
- ⚠️ **段落**: 従来通り改行は空白に変換（正常動作）

### 📦 対象ファイル

- `examples/elements/skill-template.txt` - CoC6thスキルロール項目で改善確認
- その他のテンプレートファイル全般で可読性向上

## Test plan

- [x] シンプルな複数行ブロックでの改行テスト
- [x] skill-template.txt での実際の改善確認
- [x] npc-template.txt での動作確認
- [x] 段落の改行処理が影響を受けないことを確認
- [x] 複合ブロック（枠線+太字など）での改行処理確認
- [x] HTMLエスケープ処理が正常に動作することを確認

## 利点

🎯 **直感的な記法**: ユーザーが改行したとおりに表示される
📊 **構造化データの可読性向上**: スキルロール項目、NPC情報等が見やすくなる  
🛠️ **既存機能への影響なし**: 段落や他の機能は従来通り動作

同人作家など非技術者にとって、より直感的で使いやすいツールになります。

🤖 Generated with [Claude Code](https://claude.ai/code)