### PR TITLE
fix: GitHub Actions大量失敗の原因修正

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,7 +93,7 @@ jobs:
     
     - name: Upload E2E Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: e2e-test-results-${{ matrix.os }}-py${{ matrix.python-version }}
         path: |
@@ -116,7 +116,7 @@ jobs:
     
     steps:
     - name: Download all test artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: ./test-artifacts
     
@@ -168,6 +168,6 @@ jobs:
         echo "Running basic performance validation..."
         
         # 簡単なパフォーマンステスト
-        time python -m kumihan_formatter.cli examples/sample.txt -o temp_perf_output --no-preview
+        time python -m kumihan_formatter.cli examples/01-quickstart.txt -o temp_perf_output --no-preview
         
         echo "E2E performance check completed"


### PR DESCRIPTION
## 概要
GitHub Actionsで大量の失敗メールが送信される原因となっていた非推奨artifact actionsを修正しました。

## 問題の原因
GitHubが`actions/upload-artifact@v3`と`actions/download-artifact@v3`を非推奨化し、これらを使用するワークフローが自動的に失敗するようになったため。

## 修正内容

### 🔧 非推奨アクション更新
- `actions/upload-artifact: v3` → `v4`
- `actions/download-artifact: v3` → `v4`

### 📂 ファイル参照修正
- E2Eテストで存在しない`examples/sample.txt`を参照していた問題を修正
- `examples/01-quickstart.txt`に変更

### 🎯 影響範囲
以下のワークフローが修正されます：
- **E2E Tests**: クロスプラットフォームテスト
- **e2e-cross-platform-validation**: プラットフォーム間整合性チェック
- **e2e-performance-check**: パフォーマンス基準チェック

## 効果

### ✅ 解決される問題
- 大量のAction失敗メール送信停止
- E2Eテストの正常実行復旧
- CI/CDパイプラインの安定化

### 📊 修正前の状況
```
X This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3
X This request has been automatically failed because it uses a deprecated version of actions/download-artifact: v3
X Process completed with exit code 4.
```

### ✅ 修正後の期待結果
- 全ワークフローの正常実行
- アーティファクトの正常なアップロード・ダウンロード
- E2Eテストの安定実行

## テスト結果
このPRマージ後、mainブランチでのワークフロー実行が正常化することを確認予定。

Fixes: 大量のGitHub Actions失敗メール問題

🤖 Generated with [Claude Code](https://claude.ai/code)