### PR TITLE
fix: E2Eテストのbeautifulsoup4依存関係修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "black>=23.0",
     "isort>=5.0",
     "flake8>=6.0",
+    "beautifulsoup4>=4.9",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## 概要
E2Eテストで「ModuleNotFoundError: No module named 'bs4'」エラーが発生していた問題を修正しました。

## 問題の原因
E2Eテストのvalidation.pyでBeautifulSoupを使用しているにも関わらず、pyproject.tomlのdev dependenciesに`beautifulsoup4`が含まれていなかったため。

## 修正内容

### 📦 依存関係追加
```toml
dev = [
    "pytest>=7.0",
    "pytest-cov>=4.0", 
    "black>=23.0",
    "isort>=5.0",
    "flake8>=6.0",
    "beautifulsoup4>=4.9",  # 追加
]
```

### 🎯 影響範囲
- E2EテストのHTML検証機能が正常動作
- dev/tests/e2e/utils/validation.pyのBeautifulSoup import が成功

## 効果

### ✅ 解決される問題
```bash
# 修正前
ImportError: No module named 'bs4'

# 修正後  
E2Eテストが正常実行
```

### 📊 関連ファイル
- `dev/tests/e2e/utils/validation.py`: BeautifulSoup4を使用
- 全E2Eテストファイル: validation.pyを間接的に使用

## テスト結果
このPRマージ後、E2Eテストが正常実行され、Action失敗メールが完全に解消される予定。

Fixes: E2EテストのBeautifulSoup依存関係エラー

🤖 Generated with [Claude Code](https://claude.ai/code)