### PR TITLE
fix: file_ops.pyでUIが未定義のflake8エラーを修正

### DIFF
--- a/kumihan_formatter/core/file_ops.py
+++ b/kumihan_formatter/core/file_ops.py
@@ -20,6 +20,10 @@ class UIProtocol(Protocol):
     def duplicate_files(self, duplicates: dict) -> None: ...
     def info(self, message: str, details: str = None) -> None: ...
     def hint(self, message: str, details: str = None) -> None: ...
+    def file_error(self, file_path: str, message: str) -> None: ...
+    def encoding_error(self, file_path: str) -> None: ...
+    def permission_error(self, error: str) -> None: ...
+    def unexpected_error(self, error: str) -> None: ...
 
 
 class FileOperations:
@@ -315,22 +319,26 @@ class PathValidator:
 class ErrorHandler:
     """Centralized error handling for file operations"""
     
-    @staticmethod
-    def handle_file_not_found(file_path: str) -> None:
+    def __init__(self, ui: Optional[UIProtocol] = None):
+        """Initialize with optional UI instance"""
+        self.ui = ui
+    
+    def handle_file_not_found(self, file_path: str) -> None:
         """Handle file not found error"""
-        ui.file_error(file_path, "ファイルが見つかりません")
+        if self.ui:
+            self.ui.file_error(file_path, "ファイルが見つかりません")
     
-    @staticmethod
-    def handle_encoding_error(file_path: str) -> None:
+    def handle_encoding_error(self, file_path: str) -> None:
         """Handle encoding error"""
-        ui.encoding_error(file_path)
+        if self.ui:
+            self.ui.encoding_error(file_path)
     
-    @staticmethod
-    def handle_permission_error(error: str) -> None:
+    def handle_permission_error(self, error: str) -> None:
         """Handle permission error"""
-        ui.permission_error(error)
+        if self.ui:
+            self.ui.permission_error(error)
     
-    @staticmethod
-    def handle_unexpected_error(error: str) -> None:
+    def handle_unexpected_error(self, error: str) -> None:
         """Handle unexpected error"""
-        ui.unexpected_error(error)
+        if self.ui:
+            self.ui.unexpected_error(error)


### PR DESCRIPTION
## Summary
- ErrorHandlerクラスのstatic methodをinstance methodに変更
- UIProtocolに不足していたエラーハンドリング用メソッドを追加
- GitHub Actions CI/CDのflake8エラー（F821 undefined name 'ui'）を修正

## 背景
PR #185のマージ後、GitHub Actions CI/CDでflake8エラーが発生：
```
F821 undefined name 'ui' (4箇所)
```

## 修正内容
### ErrorHandlerクラス修正
- `@staticmethod` → instance methodに変更
- UIインスタンスを依存性注入で受け取り
- エラーハンドリング時にUI存在チェックを追加

### UIProtocol拡張
- `file_error()`, `encoding_error()` 等を追加
- 型安全性を確保しつつ循環依存を回避

## 効果
- GitHub Actions CI/CDが正常実行される
- 依存性注入パターンの統一でコード品質向上
- 型安全なエラーハンドリングの実現

## Test plan
- [x] flake8エラーが解消されることを確認
- [x] 既存機能に影響がないことを確認
- [x] ErrorHandler使用箇所の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)