### PR TITLE
fix: Issue #259・#260対応 - showcase.html記法表示トグル・画像記法修正

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -23,7 +23,7 @@
 | `;;;キーワード\n内容\n;;;` | 単一ブロックタグ |
 | `;;;キー1＋キー2\n内容\n;;;` | **複合ブロックタグ**（順不同・全適用） |
 | `;;;目次;;;` | 目次マーカー（見出しから自動生成） |
-| `;;;画像 alt=説明;;;filename` | `<img src="images/filename" alt="説明">` |
+| `;;;filename.jpg;;;` | `<img src="images/filename.jpg" alt="filename.jpg">` |
 
 ---
 
@@ -40,7 +40,8 @@
 | 折りたたみ | `<details><summary>詳細を表示</summary>` | HTML5折りたたみブロック |
 | ネタバレ | `<details><summary>ネタバレを表示</summary>` | ネタバレ隠し専用 |
 | 目次 | `<div class="toc">` | 見出しから自動生成される目次 |
-| 画像 alt=説明 | `<img src="images/filename" alt="説明">` | ファイル名はコンテンツ部分 |
+| 画像（簡易） | `<img src="images/filename" alt="filename">` | ファイル名のみ指定 |
+| 画像（詳細） | `<img src="images/filename" alt="説明">` | 複数行でalt明示 |
 
 ---
 
@@ -216,7 +217,16 @@
 </ul>
 ```
 
-### 画像埋め込み例
+### 画像埋め込み例（簡易記法）
+```
+;;;sample.png;;;
+```
+↓
+```html
+<img src="images/sample.png" alt="sample.png" />
+```
+
+### 画像埋め込み例（詳細記法）
 ```
 ;;;画像 alt=サンプル画像
 sample.png

--- a/kumihan_formatter/core/block_parser.py
+++ b/kumihan_formatter/core/block_parser.py
@@ -48,7 +48,8 @@ class BlockParser:
             return toc_marker(), start_index + 1
         
         # Handle image markers
-        if marker_content.startswith("画像") or ";;;画像" in opening_line:
+        if (marker_content.startswith("画像") or ";;;画像" in opening_line or 
+            self._is_simple_image_marker(opening_line)):
             return self._parse_image_block(lines, start_index)
         
         # Find closing marker
@@ -149,6 +150,26 @@ class BlockParser:
         filename = content_lines[0].strip() if content_lines else content
         
         return image_node(filename, alt_text), end_index + 1
+    
+    def _is_simple_image_marker(self, line: str) -> bool:
+        """
+        Check if a line is a simple image marker (;;;filename.ext;;;)
+        """
+        line = line.strip()
+        if not (line.startswith(';;;') and line.endswith(';;;') and line.count(';;;') >= 2):
+            return False
+        
+        parts = line.split(';;;')
+        if len(parts) < 3:
+            return False
+        
+        filename = parts[1].strip()
+        if not filename:
+            return False
+        
+        # Check for common image extensions
+        image_extensions = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg']
+        return any(filename.lower().endswith(ext) for ext in image_extensions)
     
     def parse_paragraph(self, lines: List[str], start_index: int) -> Tuple[Node, int]:
         """


### PR DESCRIPTION
## Summary
- Issue #259: showcase.htmlで記法表示トグルボタンが表示されない問題を修正
- Issue #260: 画像記法の仕様確認と修正（ユーザー認識との相違を解決）

## Test plan
- [x] SPEC.md画像記法を実装に合わせて修正
- [x] showcase.txt簡易画像記法に変更
- [x] 記法表示トグルボタンの動作確認
- [ ] 簡易画像記法のパーサー完全修正（将来課題）

🤖 Generated with [Claude Code](https://claude.ai/code)