### PR TITLE
fix: Issue #263 - UI改善（枠線内リストマーカー変換・折りたたみ装飾強化）

### DIFF
--- a/kumihan_formatter/core/rendering/html_utils.py
+++ b/kumihan_formatter/core/rendering/html_utils.py
@@ -66,6 +66,83 @@ def process_text_content(text: str) -> str:
     return processed_text
 
 
+def process_block_content(text: str) -> str:
+    """
+    Process block content, converting list markers and newlines
+    
+    Args:
+        text: Raw block content
+    
+    Returns:
+        str: Processed HTML with list markers converted and line breaks
+    """
+    if not text:
+        return text
+    
+    # Check if text already contains HTML tags (from inline processing)
+    if contains_html_tags(text):
+        # Process text with existing HTML tags
+        processed_text = _convert_list_markers_with_html(text)
+        processed_text = re.sub(r'\r?\n', '<br>', processed_text)
+    else:
+        # First convert list markers, then escape HTML, then convert newlines
+        processed_text = _convert_list_markers(text)
+        processed_text = escape(processed_text)
+        processed_text = re.sub(r'\r?\n', '<br>', processed_text)
+    
+    return processed_text
+
+
+def _convert_list_markers(text: str) -> str:
+    """
+    Convert list markers (- and ・) in plain text
+    
+    Args:
+        text: Plain text content
+    
+    Returns:
+        str: Text with list markers converted
+    """
+    lines = text.split('\n')
+    converted_lines = []
+    
+    for line in lines:
+        # Convert line-starting list markers
+        if re.match(r'^(\s*)-\s', line):
+            # Replace - with ・ (middle dot)
+            converted_line = re.sub(r'^(\s*)-\s', r'\1・ ', line)
+            converted_lines.append(converted_line)
+        else:
+            converted_lines.append(line)
+    
+    return '\n'.join(converted_lines)
+
+
+def _convert_list_markers_with_html(text: str) -> str:
+    """
+    Convert list markers in text that may contain HTML tags
+    
+    Args:
+        text: Text content that may contain HTML
+    
+    Returns:
+        str: Text with list markers converted
+    """
+    lines = text.split('\n')
+    converted_lines = []
+    
+    for line in lines:
+        # Convert line-starting list markers, being careful with HTML
+        if re.match(r'^(\s*)-\s', line):
+            # Replace - with ・ (middle dot)
+            converted_line = re.sub(r'^(\s*)-\s', r'\1・ ', line)
+            converted_lines.append(converted_line)
+        else:
+            converted_lines.append(line)
+    
+    return '\n'.join(converted_lines)
+
+
 def contains_html_tags(text: str) -> bool:
     """
     Check if text contains HTML tags


### PR DESCRIPTION
## Summary

Issue #263で指摘された2つのUI問題を解決しました：

• **枠線内リストマーカー変換修正**: 枠線ブロック内の `- ` が `・` (中黒) に正しく変換されるように
• **折りたたみブロック装飾強化**: 折りたたみ機能をより目立つよう既存のCSS装飾を活用・強化

## 技術的変更

### 🔧 コア機能修正
- `html_utils.py`: `process_block_content()` 関数を新規追加
- `element_renderer.py`: `_render_div_content()` メソッドを追加してdiv要素専用の処理

### 🎨 UI改善
- 枠線ブロック内でのリストマーカー自動変換機能
- 折りたたみブロックの既存CSS装飾（アニメーション・アイコン・ホバー効果）活用
- ネタバレ専用スタイル（⚠️ アイコン・警告配色）

### 📝 サンプル拡充
- `showcase.txt` に折りたたみ・ネタバレのサンプルコンテンツを追加
- 実際の使用例を通じて機能の有効性を実証

## Test plan

- [x] 枠線ブロック内のリストマーカーが `・` に変換されることを確認
- [x] 折りたたみブロックの視覚的装飾が適用されることを確認  
- [x] showcase.html が正常に再生成されることを確認
- [x] 既存機能に副作用がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)