### PR TITLE
fix: GitHub Actions同期・再実行用 - Issue #282対応

### DIFF
--- a/kumihan_formatter/templates/base.html.j2
+++ b/kumihan_formatter/templates/base.html.j2
@@ -379,37 +379,38 @@
         details {
             margin: 1em 0;
             padding: 0;
-            border: 2px solid #e0e6ed;
-            border-radius: 10px;
-            background-color: #f8f9fa;
-            box-shadow: 0 3px 10px rgba(0,0,0,0.08);
-            transition: all 0.3s ease;
+            border: 1px solid #d0d7de;
+            border-radius: 6px;
+            background-color: #ffffff;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+            transition: all 0.2s ease;
             overflow: hidden;
         }
 
         details:hover {
-            box-shadow: 0 6px 20px rgba(0,0,0,0.12);
-            border-color: #c6d2e0;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+            border-color: #9a9a9a;
         }
 
         details[open] {
-            border-color: #9bb5d1;
-            box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+            border-color: #007acc;
+            box-shadow: 0 2px 8px rgba(0, 122, 204, 0.1);
         }
 
         details summary {
-            padding: 1.2em 1.5em;
+            padding: 0.8em 1em;
             font-weight: 600;
             cursor: pointer;
-            background: linear-gradient(135deg, #e9ecef 0%, #f0f3f6 100%);
-            border-radius: 8px 8px 0 0;
+            background-color: #f6f8fa;
+            border-radius: 5px 5px 0 0;
             user-select: none;
-            transition: all 0.3s ease;
+            transition: all 0.2s ease;
             position: relative;
-            padding-left: 3em;
+            padding-left: 2.5em;
             list-style: none;
-            color: #495057;
-            font-size: 1.05em;
+            color: #24292f;
+            font-size: 1em;
+            border-bottom: 1px solid #d0d7de;
         }
         
         /* Webkit browsers */
@@ -418,42 +419,42 @@
         }
 
         details[open] summary {
-            border-bottom: 2px solid #d0dae6;
-            border-radius: 8px 8px 0 0;
-            background: linear-gradient(135deg, #d6dde6 0%, #e1e8f0 100%);
+            background-color: #e7f3ff;
+            border-bottom: 1px solid #007acc;
+            color: #0969da;
         }
 
         details summary:hover {
-            background: linear-gradient(135deg, #dee2e6 0%, #e8ebf0 100%);
-            transform: translateY(-1px);
+            background-color: #e7f3ff;
         }
 
         details[open] summary:hover {
-            background: linear-gradient(135deg, #c8d2dd 0%, #d3dce8 100%);
+            background-color: #dbeafe;
         }
 
-        /* 展開アイコン */
+        /* 展開アイコン - 控えめなデザイン */
         details summary::before {
             content: '▶';
             position: absolute;
-            left: 1.2em;
+            left: 0.8em;
             top: 50%;
             transform: translateY(-50%);
-            transition: all 0.3s ease;
-            font-size: 1em;
-            color: #6c757d;
-            text-shadow: 0 1px 2px rgba(0,0,0,0.1);
+            transition: all 0.2s ease;
+            font-size: 0.8em;
+            color: #656d76;
+            width: auto;
+            height: auto;
+            line-height: 1;
         }
 
         details[open] summary::before {
             transform: translateY(-50%) rotate(90deg);
-            color: #495057;
+            color: #0969da;
         }
 
         /* 折りたたみコンテンツ */
         details > *:not(summary) {
-            padding: 1.2em 1.5em;
-            padding-top: 1em;
+            padding: 1em;
             background-color: #ffffff;
             line-height: 1.7;
         }
@@ -492,22 +493,52 @@
 
         /* ネタバレブロック専用スタイル */
         details.spoiler {
-            border-color: #f0ad4e;
-            background-color: #fff3cd;
+            border-color: #d73a49;
+            background-color: #ffffff;
+        }
+
+        details.spoiler:hover {
+            border-color: #b31d28;
+        }
+
+        details.spoiler[open] {
+            border-color: #d73a49;
         }
 
         details.spoiler summary {
-            background-color: #f0ad4e;
-            color: #856404;
+            background-color: #fff5f5;
+            color: #d73a49;
+            border-bottom: 1px solid #fdbdbd;
         }
 
         details.spoiler summary:hover {
-            background-color: #ec971f;
+            background-color: #fef2f2;
+        }
+
+        details.spoiler[open] summary {
+            background-color: #fff1f1;
+            border-bottom: 1px solid #d73a49;
+        }
+
+        details.spoiler[open] summary:hover {
+            background-color: #fef2f2;
         }
 
         details.spoiler summary::after {
-            content: ' ⚠️';
-            margin-left: 0.5em;
+            content: '⚠️';
+            position: absolute;
+            right: 1em;
+            top: 50%;
+            transform: translateY(-50%);
+            font-size: 0.9em;
+        }
+
+        details.spoiler summary::before {
+            color: #d73a49;
+        }
+
+        details.spoiler[open] summary::before {
+            color: #d73a49;
         }
 
         /* ダークテーマでの折りたたみブロック調整 */


### PR DESCRIPTION
## Summary
GitHub Actionsワークフロー大量キャンセル後の同期とCSS改善の確実な反映

## 背景
- 35個のワークフローがQUEUEDで9時間以上停止
- 緊急対応で全ワークフローをキャンセル
- PR #281が手動マージされたがリモートに未反映
- 折りたたみブロックのCSS改善（GitHub風デザイン）を確実に反映

## 変更内容
- CSS品質改善の手動マージ内容をリモートmainに同期
- GitHub Actions再実行用の空コミット
- 折りたたみブロックの視覚的改善を本格運用

## 関連Issue
- Closes #282 (GitHub Actions congestion emergency response)
- Related to #280 (CSS quality improvements)

🤖 Generated with [Claude Code](https://claude.ai/code)