### PR TITLE
docs: Issue作成時のラベル付与を必須化

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Kumihan-Formatter への貢献ガイドライン
 ### 1. Issue の作成
 - バグ報告や機能提案は Issue で行ってください
 - 既存の Issue を確認してから新規作成してください
+- Issue には適切な Label を付与して管理してください
 
 ### 2. Pull Request
 - `main` ブランチへの直接コミットは避けてください


### PR DESCRIPTION
## Summary

CONTRIBUTING.mdを更新し、Issue作成時の適切なラベル付与を必須化しました。

### 変更内容
- ✅ Issue作成セクションにラベル付与の義務を追加
- ✅ Issue管理の効率化を図る

### 目的
- Issue分類の統一化
- 優先度や種別の明確化
- プロジェクト管理の効率向上

## Test plan

- [x] ドキュメントの整合性確認
- [x] 記載内容の妥当性検証

🤖 Generated with [Claude Code](https://claude.ai/code)