### PR TITLE
fix: ネタバレブロックにspoilerクラスを正しく適用

### DIFF
--- a/kumihan_formatter/core/rendering/compound_renderer.py
+++ b/kumihan_formatter/core/rendering/compound_renderer.py
@@ -68,7 +68,7 @@ class CompoundElementRenderer:
         elif keyword == '折りたたみ':
             return f'<details><summary>詳細を表示</summary>{content}</details>'
         elif keyword == 'ネタバレ':
-            return f'<details><summary>ネタバレを表示</summary>{content}</details>'
+            return f'<details class="spoiler"><summary>ネタバレを表示</summary>{content}</details>'
         else:
             # Fallback for unknown keywords
             return f'<span class="{escape(keyword)}">{content}</span>'

--- a/kumihan_formatter/core/rendering/element_renderer.py
+++ b/kumihan_formatter/core/rendering/element_renderer.py
@@ -134,8 +134,12 @@ class ElementRenderer:
         
         summary = node.get_attribute('summary', '詳細を表示')
         
+        # Check if this is a spoiler block
+        is_spoiler = node.get_attribute('spoiler', False) or summary == 'ネタバレを表示'
+        class_attr = ' class="spoiler"' if is_spoiler else ''
+        
         # Wrap content in a div to ensure CSS selectors work properly
-        return f'<details><summary>{escape_html(summary)}</summary><div class="details-content">{content}</div></details>'
+        return f'<details{class_attr}><summary>{escape_html(summary)}</summary><div class="details-content">{content}</div></details>'
     
     def render_preformatted(self, node: Node) -> str:
         """Render preformatted text"""


### PR DESCRIPTION
## 📝 概要

Issue #314 で報告されたネタバレブロックのCSSクラス未適用不具合を修正しました。

## 🔧 修正内容

### 修正ファイル

1. **`kumihan_formatter/core/rendering/compound_renderer.py`**
   - `_wrap_with_keyword`メソッドのネタバレキーワード処理時に`class="spoiler"`を追加

2. **`kumihan_formatter/core/rendering/element_renderer.py`**
   - `render_details`メソッドでsummaryテキストが「ネタバレを表示」の場合にspoilerクラスを適用する判定ロジックを追加

### 修正前の出力
```html
<details>
  <summary>ネタバレを表示</summary>
  <div class="details-content">内容</div>
</details>
```

### 修正後の出力
```html
<details class="spoiler">
  <summary>ネタバレを表示</summary>
  <div class="details-content">内容</div>
</details>
```

## 📊 影響範囲

- ✅ ネタバレブロックが通常の折りたたみブロックと視覚的に区別される
- ✅ 警告アイコン（⚠️）が正しく表示される  
- ✅ ネタバレ専用の赤系スタイルが適用される
- ✅ 既存の折りたたみブロック機能に影響なし

## 🧪 テスト結果

テストファイルでの動作確認済み：

```
;;;折りたたみ
通常の折りたたみブロック
;;;

;;;ネタバレ
ネタバレブロック（赤系スタイル+警告アイコン付き）
;;;
```

Closes #314

🤖 Generated with [Claude Code](https://claude.ai/code)