### PR TITLE
fix: 全Windowsバッチファイルのパス問題を修正

### DIFF
--- a/WINDOWS/サンプル実行.bat
+++ b/WINDOWS/サンプル実行.bat
@@ -111,7 +111,7 @@ echo %GREEN%[完了] 環境確認完了%NC%
 echo.
 
 rem 出力ディレクトリの準備
-set "OUTPUT_BASE=..\dist\samples"
+set "OUTPUT_BASE=%~dp0..\dist\samples"
 
 rem Check if output directory exists and is not empty
 if exist "%OUTPUT_BASE%" (
@@ -366,7 +366,11 @@ echo.
 echo 出力フォルダを開きますか？ [y/N]
 set /p choice=""
 if /i "%choice%"=="y" (
-    explorer "%OUTPUT_BASE%"
+    if exist "%OUTPUT_BASE%" (
+        explorer "%OUTPUT_BASE%"
+    ) else (
+        echo %RED%[エラー] 出力フォルダが見つかりません: %OUTPUT_BASE%%NC%
+    )
 )
 
 echo.

--- a/WINDOWS/記法チェッカー.bat
+++ b/WINDOWS/記法チェッカー.bat
@@ -30,7 +30,7 @@ if %errorlevel% neq 0 (
 )
 
 REM 仮想環境の確認
-if not exist "..\\.venv" (
+if not exist "%~dp0..\\.venv" (
     echo [警告] 仮想環境が見つかりません
     echo [ヒント] 変換ツール.bat を先に実行してセットアップを完了してください
     echo.
@@ -39,7 +39,7 @@ if not exist "..\\.venv" (
 )
 
 echo [設定] 仮想環境をアクティベート中...
-call "..\\.venv\\Scripts\\activate.bat"
+call "%~dp0..\\.venv\\Scripts\\activate.bat"
 
 REM 依存関係の確認
 python -c "import click, jinja2, rich" 2>nul

--- a/Windows用初回セットアップ.bat
+++ b/Windows用初回セットアップ.bat
@@ -94,8 +94,8 @@ set /p choice="[選択] 選択してください [Y/N/S]: "
 if /i "%choice%"=="y" (
     echo.
     echo [開始] 変換ツールを起動しています...
-    if exist "WINDOWS\変換ツール.bat" (
-        call "WINDOWS\変換ツール.bat"
+    if exist "%~dp0WINDOWS\変換ツール.bat" (
+        call "%~dp0WINDOWS\変換ツール.bat"
     ) else (
         echo [エラー] 変換ツール.bat が見つかりません
         echo.
@@ -108,8 +108,8 @@ if /i "%choice%"=="y" (
     echo.
     echo [統計] サンプルを実行しています...
     echo.
-    if exist "WINDOWS\サンプル実行.bat" (
-        call "WINDOWS\サンプル実行.bat"
+    if exist "%~dp0WINDOWS\サンプル実行.bat" (
+        call "%~dp0WINDOWS\サンプル実行.bat"
         echo.
         echo サンプル確認が完了しました！
         echo.
@@ -117,8 +117,8 @@ if /i "%choice%"=="y" (
         if /i "!convert_choice!"=="y" (
             echo.
             echo [開始] 変換ツールを起動しています...
-            if exist "WINDOWS\変換ツール.bat" (
-                call "WINDOWS\変換ツール.bat"
+            if exist "%~dp0WINDOWS\変換ツール.bat" (
+                call "%~dp0WINDOWS\変換ツール.bat"
             ) else (
                 echo [エラー] エラー: 変換ツール.bat が見つかりません
                 echo 手動で 変換ツール.bat をダブルクリックしてください


### PR DESCRIPTION
## Summary
- 「The system cannot find the drive specified.」エラーを完全解決
- 全Windowsバッチファイルの相対パス問題を統一的に修正
- %~dp0を使用した絶対パス処理を実装

## 修正内容
- **サンプル実行.bat**: 相対パス `..\dist\samples` を絶対パス `%~dp0..\dist\samples` に変更、explorer実行前の存在確認追加
- **記法チェッカー.bat**: 仮想環境パス `..\\.venv` を絶対パス `%~dp0..\\.venv` に変更
- **Windows用初回セットアップ.bat**: WINDOWSフォルダ参照を絶対パス `%~dp0WINDOWS\` に変更

## 解決する問題
- Issue #361 で修正した変換ツール.bat と同様の問題が他のbatファイルでも発生
- クローンし直しても発生する根本的なWindows パス処理の問題
- デスクトップ実行時とプロジェクト内実行時のパス解決の不整合

## Test plan
- [x] Windows 10/11 環境でのテスト実行
- [x] 各batファイルの正常動作確認
- [x] explorerコマンドの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)