### PR TITLE
fix: Issue #379 Windows環境権限テストを一時的にスキップ

### DIFF
--- a/tests/e2e/test_error_handling.py
+++ b/tests/e2e/test_error_handling.py
@@ -8,11 +8,14 @@ E2Eテスト: エラーハンドリングE2Eテスト
 """
 
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from unittest import TestCase
+
+import pytest
 
 
 class TestErrorHandling(TestCase):
@@ -90,6 +93,10 @@ class TestErrorHandling(TestCase):
             f"or stdout: '{result.stdout}'",
         )
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Windows file permission tests need platform-specific " "implementation",
+    )
     def test_permission_denied_input_file_error(self):
         """読み込み権限なし入力ファイルエラーテスト"""
         # 権限なしファイルを作成
@@ -133,6 +140,10 @@ class TestErrorHandling(TestCase):
             # 権限を戻す（クリーンアップのため）
             os.chmod(restricted_file, 0o644)
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Windows file permission tests need platform-specific " "implementation",
+    )
     def test_permission_denied_output_directory_error(self):
         """書き込み権限なし出力ディレクトリエラーテスト"""
         # 正常な入力ファイルを作成
@@ -339,7 +350,9 @@ d6  // ダイス数が指定されていない
 |-----|-----|-----|-----|-----|
 """
             for row in range(100):
-                memory_intensive_content += f"| データ{row}A | データ{row}B | データ{row}C | データ{row}D | データ{row}E |\n"
+                memory_intensive_content += (
+                    f"| データ{row}A | データ{row}B | データ{row}C | データ{row}D | データ{row}E |\n"
+                )
 
         memory_file = self._create_test_file(
             "memory_intensive.txt", memory_intensive_content
@@ -538,6 +551,4 @@ alert('このスクリプトは実行されません');
                 self.assertIn("<body", content)
                 self.assertIn("</body>", content)
                 # 基本的なコンテンツが含まれることを確認（見出しやリストなど）
-                self.assertTrue(
-                    len(content) > 1000
-                )  # HTMLが適切なサイズであることを確認
+                self.assertTrue(len(content) > 1000)  # HTMLが適切なサイズであることを確認

--- a/tests/e2e/test_simple_e2e.py
+++ b/tests/e2e/test_simple_e2e.py
@@ -8,11 +8,14 @@ E2Eテスト: 実際の使用シナリオのE2Eテスト
 """
 
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from unittest import TestCase
+
+import pytest
 
 
 class TestSimpleE2E(TestCase):
@@ -420,9 +423,7 @@ def hello():
 """
         test_file = self._create_test_file("error_recovery.txt", content)
 
-        result = self._run_conversion(
-            test_file, ["--no-syntax-check"]
-        )  # エラーを無視するオプション
+        result = self._run_conversion(test_file, ["--no-syntax-check"])  # エラーを無視するオプション
 
         # エラーがあっても処理継続
         self.assertIn(result.returncode, [0, 1])
@@ -455,6 +456,10 @@ def hello():
             )
         )
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Windows file permission tests need platform-specific " "implementation",
+    )
     def test_permission_denied_input(self):
         """読み込み権限なし入力ファイル"""
         content = "権限テスト"
@@ -468,6 +473,10 @@ def hello():
         finally:
             os.chmod(restricted_file, 0o644)
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Windows file permission tests need platform-specific " "implementation",
+    )
     def test_permission_denied_output(self):
         """書き込み権限なし出力ディレクトリ"""
         content = "# 権限テスト\n\n正常なコンテンツです。"
@@ -599,9 +608,7 @@ d6
 |-----|-----|-----|
 """
             for row in range(50):
-                memory_intensive_content += (
-                    f"| データ{row}A | データ{row}B | データ{row}C |\n"
-                )
+                memory_intensive_content += f"| データ{row}A | データ{row}B | データ{row}C |\n"
 
         memory_file = self._create_test_file(
             "memory_intensive.txt", memory_intensive_content

--- a/tests/integration/test_file_io_integration.py
+++ b/tests/integration/test_file_io_integration.py
@@ -7,10 +7,13 @@
 """
 
 import os
+import platform
 import shutil
 import tempfile
 from pathlib import Path
 from unittest import TestCase
+
+import pytest
 
 from kumihan_formatter.core.encoding_detector import EncodingDetector
 from kumihan_formatter.core.file_ops import FileOperations
@@ -80,6 +83,10 @@ class TestFileIOIntegration(TestCase):
         with self.assertRaises(FileNotFoundError):
             self.file_ops.read_text_file(nonexistent_file)
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Windows file permission tests need platform-specific " "implementation",
+    )
     def test_read_permission_denied_file(self):
         """読み込み権限なしファイルテスト"""
         content = "権限テスト"
@@ -152,6 +159,10 @@ class TestFileIOIntegration(TestCase):
         # 上書きされたことを確認
         self.assertEqual(output_file.read_text(encoding="utf-8"), new_content)
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Windows file permission tests need platform-specific " "implementation",
+    )
     def test_write_permission_denied_directory(self):
         """書き込み権限なしディレクトリテスト"""
         content = "権限テスト"

--- a/tests/integration/test_simple_integration.py
+++ b/tests/integration/test_simple_integration.py
@@ -7,11 +7,14 @@
 """
 
 import os
+import platform
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
 from unittest import TestCase
+
+import pytest
 
 
 class TestSimpleIntegration(TestCase):
@@ -191,6 +194,10 @@ class TestSimpleIntegration(TestCase):
         with self.assertRaises(FileNotFoundError):
             nonexistent_file.read_text(encoding="utf-8")
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Windows file permission tests need platform-specific " "implementation",
+    )
     def test_file_read_permission_denied(self):
         """読み込み権限なしファイルテスト"""
         content = "権限テスト"
@@ -246,6 +253,10 @@ class TestSimpleIntegration(TestCase):
         test_file.write_text(new_content, encoding="utf-8")
         self.assertEqual(test_file.read_text(encoding="utf-8"), new_content)
 
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="Windows file permission tests need platform-specific " "implementation",
+    )
     def test_file_write_permission_denied(self):
         """書き込み権限なしディレクトリテスト"""
         readonly_dir = Path(self.test_dir) / "readonly"


### PR DESCRIPTION
## 概要
Windows環境でのファイル権限テスト失敗問題（Issue #379）の暫定対応として、該当するテストをpytest.skipifでスキップするよう修正しました。

## 変更内容

### 修正ファイル
- `tests/e2e/test_error_handling.py`: 権限エラーテスト2件をWindows環境でスキップ
- `tests/e2e/test_simple_e2e.py`: 権限テスト2件をWindows環境でスキップ
- `tests/integration/test_file_io_integration.py`: 権限テスト2件をWindows環境でスキップ
- `tests/integration/test_simple_integration.py`: 権限テスト2件をWindows環境でスキップ

### 実装方法
```python
@pytest.mark.skipif(
    platform.system() == "Windows",
    reason="Windows file permission tests need platform-specific "
    "implementation",
)
def test_permission_denied_input(self):
    # 権限テストの実装
```

## 解決する問題

### Before (Issue #379)
- ❌ Windows環境でファイル権限テストが失敗
- ❌ CI/CDでWindows環境のテスト成功率が低下
- ❌ `chmod`がWindows環境で期待通りに動作しない

### After (この修正)
- ✅ Windows環境でテストがスキップされ、CIが安定
- ✅ Unix系OSでは従来通り権限テストが実行される
- ✅ 最小限の変更で問題を解決

## 今後の対応

この修正は暫定対応です。Windows固有の権限実装については別途Issue #381で対応予定です。

## 関連Issue

Fixes #379

🤖 Generated with [Claude Code](https://claude.ai/code)