### PR TITLE
fix: isortチェック再有効化と設定統一

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,16 +54,15 @@ jobs:
           black --check kumihan_formatter
         fi
 
-    # 一時的に無効化 - Issue #383 Windows権限テスト検証のため
-    # - name: Import sort check with isort
-    #   shell: bash
-    #   run: |
-    #     if [ -d "tests" ]; then
-    #       isort --check-only kumihan_formatter tests
-    #     else
-    #       echo "tests directory not found, checking only kumihan_formatter"
-    #       isort --check-only kumihan_formatter
-    #     fi
+    - name: Import sort check with isort
+      shell: bash
+      run: |
+        if [ -d "tests" ]; then
+          isort --check-only kumihan_formatter tests
+        else
+          echo "tests directory not found, checking only kumihan_formatter"
+          isort --check-only kumihan_formatter
+        fi
 
     - name: Test with pytest
       shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,12 +21,12 @@ repos:
         language_version: python3
         args: [--line-length=88]
 
-  # Import整理 (一時的に無効化 - Issue #383 Windows権限テスト検証のため)
-  # - repo: https://github.com/pycqa/isort
-  #   rev: 6.0.1
-  #   hooks:
-  #     - id: isort
-  #       args: [--profile=black, --line-length=88]
+  # Import整理
+  - repo: https://github.com/pycqa/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        args: [--profile=black, --line-length=88]
 
   # 基本的な構文チェック
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
## Summary
- Windows権限テスト実装完了により、一時的に無効化していたisortチェックを再有効化
- pre-commit設定とGitHub Actions設定の整合性を確保
- CI/CDパイプラインの完全復旧

## 主な変更内容
### 復旧した設定
- `.pre-commit-config.yaml`: isortフックを再有効化
- `.github/workflows/test.yml`: isortチェックステップを再有効化

### 確認済み項目
- [x] ローカルでのisortチェック正常動作
- [x] pre-commitフック正常動作
- [x] 設定の整合性確認

## 背景
Issue #383のWindows権限テスト実装時に、isortの設定競合によりCI/CDが阻害されていたため、一時的にisortチェックを無効化していました。

Windows権限テストの実装が完了し、Core機能の動作確認が取れたため、isortチェックを再有効化して正常なCI/CDパイプラインに復旧します。

## Test plan
- [x] ローカルでのisortチェック実行
- [x] pre-commitフックの動作確認
- [ ] CI/CDでの全プラットフォーム動作確認

## 関連
- 前PR: #384 (Windows権限テスト実装)
- 本PRにより開発環境の完全正常化

🤖 Generated with [Claude Code](https://claude.ai/code)