### PR TITLE
feat: アルファ版リリース機能実装 - プロプライエタリライセンス移行

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -1,0 +1,100 @@
+name: Alpha Release Build
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: [ "v*-alpha*" ]
+  workflow_dispatch:
+    inputs:
+      version_suffix:
+        description: 'Alpha version suffix (e.g., alpha.1)'
+        required: true
+        default: 'alpha.1'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            platform: macos
+            executable_name: kumihan_formatter_macos
+          - os: windows-latest
+            platform: windows
+            executable_name: kumihan_formatter_windows.exe
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements-dev.txt
+        pip install pyinstaller
+
+    - name: Install package
+      run: pip install -e .
+
+    - name: Build executable
+      run: |
+        pyinstaller --onefile --name ${{ matrix.executable_name }} kumihan_formatter/__main__.py
+
+    - name: Test executable
+      run: |
+        ./dist/${{ matrix.executable_name }} --version
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.platform }}-executable
+        path: dist/${{ matrix.executable_name }}
+        retention-days: 30
+
+  create-release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, 'alpha')
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v3
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          macos-executable/*
+          windows-executable/*
+        draft: false
+        prerelease: true
+        name: "Alpha Release ${{ github.ref_name }}"
+        body: |
+          ## アルファ版リリース - ${{ github.ref_name }}
+
+          **⚠️ 警告: これはテスト版です**
+          - 本番環境での使用は推奨されません
+          - バグや不具合が含まれる可能性があります
+          - フィードバックをお待ちしています
+
+          ### 実行ファイル
+          - `kumihan_formatter_macos`: macOS用実行ファイル
+          - `kumihan_formatter_windows.exe`: Windows用実行ファイル
+
+          ### 使用方法
+          1. お使いのOS用のファイルをダウンロード
+          2. 実行権限を付与（macOSの場合）
+          3. コマンドラインから実行
+
+          ### ライセンス
+          このソフトウェアはプロプライエタリライセンスです。
+          改変・再配布は禁止されています。
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,16 +1,19 @@
-MIT License
+Proprietary License - All Rights Reserved
 
 Copyright (c) 2025 mo9mo9-uwu-mo9mo9
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+All rights reserved.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This software and its documentation are the proprietary and confidential
+information of mo9mo9-uwu-mo9mo9. You shall not disclose such information
+and shall use it only in accordance with the terms of the license agreement
+you entered into with mo9mo9-uwu-mo9mo9.
+
+RESTRICTIONS:
+1. You may not modify, adapt, alter, translate, or create derivative works of this software.
+2. You may not distribute, sublicense, lease, rent, loan, or otherwise transfer this software.
+3. You may not reverse engineer, decompile, disassemble, or otherwise attempt to derive the source code.
+4. You may not remove or alter any proprietary notices or labels on this software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/kumihan_formatter/__init__.py
+++ b/kumihan_formatter/__init__.py
@@ -1,3 +1,3 @@
 """Kumihan-Formatter - テキストファイルをHTMLに自動組版するCLIツール"""
 
-__version__ = "0.3.0"
+__version__ = "0.3.0-alpha.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,16 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kumihan-formatter"
-version = "0.3.0"
+version = "0.3.0-alpha.1"
 description = "CoC6th同人シナリオなどのテキストファイルをワンコマンドで配布可能なHTMLに自動組版するCLIツール"
 authors = [{name = "mo9mo9-uwu-mo9mo9"}]
 readme = "README.md"
 requires-python = ">=3.12"
-license = {text = "MIT"}
+license = {text = "Proprietary"}
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: Other/Proprietary License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
 ]
@@ -104,7 +104,7 @@ line_length = 88
 
 # バージョン管理設定
 [tool.bumpversion]
-current_version = "0.3.0"
+current_version = "0.3.0-alpha.1"
 commit = true
 tag = true
 tag_name = "v{new_version}"

--- a/scripts/build_alpha.py
+++ b/scripts/build_alpha.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+アルファ版ビルドスクリプト
+Mac/Windows用実行ファイルを生成
+"""
+
+import os
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main():
+    """アルファ版ビルドのメイン処理"""
+
+    # プロジェクトルートに移動
+    project_root = Path(__file__).parent.parent
+    os.chdir(project_root)
+
+    print("🚀 Kumihan-Formatter アルファ版ビルド開始")
+    print(f"📁 プロジェクトルート: {project_root}")
+    print(f"🖥️  プラットフォーム: {platform.system()}")
+
+    # PyInstallerがインストールされているか確認
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "PyInstaller", "--version"],
+            check=True,
+            capture_output=True,
+        )
+        print("✅ PyInstaller が見つかりました")
+    except subprocess.CalledProcessError:
+        print("❌ PyInstaller が見つかりません。インストールしています...")
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", "pyinstaller"], check=True
+        )
+
+    # プラットフォーム別の設定
+    system = platform.system()
+    if system == "Darwin":  # macOS
+        spec_file = "tools/packaging/kumihan_formatter_macos.spec"
+        output_name = "kumihan_formatter_macos"
+    elif system == "Windows":
+        spec_file = "tools/packaging/kumihan_formatter.spec"
+        output_name = "kumihan_formatter_windows.exe"
+    else:
+        print(f"❌ 未対応のプラットフォーム: {system}")
+        sys.exit(1)
+
+    # ビルド実行
+    print(f"🔨 ビルド開始: {spec_file}")
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "PyInstaller", "--clean", "--noconfirm", spec_file],
+            check=True,
+        )
+
+        # 出力ファイルの確認
+        dist_path = project_root / "dist" / output_name
+        if dist_path.exists():
+            print(f"✅ ビルド成功: {dist_path}")
+
+            # 実行テスト
+            print("🧪 実行テスト中...")
+            result = subprocess.run(
+                [str(dist_path), "--version"], capture_output=True, text=True
+            )
+            if result.returncode == 0:
+                print(f"✅ 実行テスト成功: {result.stdout.strip()}")
+            else:
+                print(f"⚠️  実行テストで警告: {result.stderr}")
+        else:
+            print(f"❌ ビルドファイルが見つかりません: {dist_path}")
+            sys.exit(1)
+
+    except subprocess.CalledProcessError as e:
+        print(f"❌ ビルドエラー: {e}")
+        sys.exit(1)
+
+    print("🎉 アルファ版ビルド完了")
+    print(f"📦 出力ファイル: dist/{output_name}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ライセンスをMITからプロプライエタリに変更（改変・再配布禁止）
- アルファ版バージョニング（0.3.0-alpha.1）に設定
- GitHub Actions でのアルファ版リリース自動化を実装

## 変更内容
- LICENSE: MIT → プロプライエタリライセンス
- pyproject.toml: ライセンス情報とバージョンを更新
- .github/workflows/alpha-release.yml: アルファ版リリース自動化
- scripts/build_alpha.py: ローカルビルド用スクリプト追加

## Test plan
- [ ] GitHub Actions ワークフローが正常に動作するか確認
- [ ] アルファ版タグでのリリース自動化をテスト
- [ ] ローカルビルドスクリプトの動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)