### PR TITLE
fix: GitHub Actions artifact actions を v4 に更新

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -50,7 +50,7 @@ jobs:
         ./dist/${{ matrix.executable_name }} --version
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.platform }}-executable
         path: dist/${{ matrix.executable_name }}
@@ -65,7 +65,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Download all artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
 
     - name: Create Release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
GitHub Actionsでv3のartifact actionsが非推奨になったため、v4に更新してアルファ版リリースを修正