### PR TITLE
fix: PyInstallerエントリーポイント修正とproject.scripts追加

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Build executable
       run: |
-        pyinstaller --onefile --name ${{ matrix.executable_name }} kumihan_formatter/__main__.py
+        pyinstaller --onefile --name ${{ matrix.executable_name }} --add-data "kumihan_formatter/templates:kumihan_formatter/templates" -c kumihan_formatter.cli:main
 
     - name: Test executable
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "pydantic>=2.0",
 ]
 
+[project.scripts]
+kumihan = "kumihan_formatter.cli:main"
+
 [project.optional-dependencies]
 dev = [
     "black>=23.0",


### PR DESCRIPTION
PyInstallerで実行ファイル作成時のエラーを修正するため、適切なエントリーポイントとproject.scriptsを追加