### PR TITLE
fix: ビルドテストワークフローのref指定を修正

### DIFF
--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -15,6 +15,9 @@ jobs:
   # リリース前にビルドテストを実行
   test-builds:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
     - name: Trigger build tests
       uses: actions/github-script@v7

--- a/.github/workflows/alpha-release.yml
+++ b/.github/workflows/alpha-release.yml
@@ -28,7 +28,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             workflow_id: 'build-test-packages.yml',
-            ref: context.ref,
+            ref: 'main',
             inputs: {
               test_windows: 'true',
               test_macos: 'true'


### PR DESCRIPTION
## Summary
- workflow_dispatchでmainブランチを明示的に指定
- タグ参照ではなくmainブランチのコードでビルドテストを実行
- アルファリリース時のビルドテスト失敗を修正

## Test plan
- [ ] 修正後のアルファリリース実行確認
- [ ] ビルドテストが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)