### PR TITLE
fix: Windowsビルドスクリプトの文字エンコーディング問題を修正

### DIFF
--- a/scripts/build/build_alpha.py
+++ b/scripts/build/build_alpha.py
@@ -15,7 +15,7 @@ def main():
     """アルファ版ビルドのメイン処理"""
 
     # プロジェクトルートに移動
-    project_root = Path(__file__).parent.parent
+    project_root = Path(__file__).parent.parent.parent
     os.chdir(project_root)
 
     print("🚀 Kumihan-Formatter アルファ版ビルド開始")
@@ -40,7 +40,7 @@ def main():
     system = platform.system()
     if system == "Darwin":  # macOS
         spec_file = "tools/packaging/kumihan_formatter_macos.spec"
-        output_name = "kumihan_formatter_macos"
+        output_name = "Kumihan-Formatter"
     elif system == "Windows":
         spec_file = "tools/packaging/kumihan_formatter.spec"
         output_name = "kumihan_formatter_windows.exe"

--- a/scripts/build/build_windows.py
+++ b/scripts/build/build_windows.py
@@ -218,13 +218,13 @@ MIT License - Copyright © 2025 mo9mo9-uwu-mo9mo9
         self, clean: bool = False, test: bool = False, upload: bool = False
     ) -> None:
         """Main build process"""
-        print("[INFO] Kumihan-Formatter Windows版ビルドを開始します...")
-        print(f"   プロジェクトディレクトリ: {self.root_dir}")
+        print("[INFO] Kumihan-Formatter Windows build starting...")
+        print(f"   Project directory: {self.root_dir}")
 
         try:
             # Check dependencies
             if not self.check_dependencies():
-                print("[ERROR] 依存関係のチェックに失敗しました")
+                print("[ERROR] Dependency check failed")
                 return False
 
             # Install PyInstaller if needed


### PR DESCRIPTION
## Summary
- Windows CI環境での日本語文字列による文字エンコーディングエラーを修正
- build_alpha.pyのプロジェクトルートパス設定を修正

## Changes
- `build_windows.py`: 日本語メッセージを英語に変更
- `build_alpha.py`: プロジェクトルートパスを正しく設定

## Test plan
- [x] アルファ版リリースワークフローでのテストビルド成功を確認

🤖 Generated with [Claude Code](https://claude.ai/code)