### PR TITLE
fix: correct .spec file path in Windows build script

### DIFF
--- a/scripts/build/build_windows.py
+++ b/scripts/build/build_windows.py
@@ -26,7 +26,9 @@ class WindowsBuilder:
         self.root_dir = root_dir or Path(__file__).parent
         self.dist_dir = self.root_dir / "dist"
         self.build_dir = self.root_dir / "build"
-        self.spec_file = self.root_dir / "kumihan_formatter.spec"
+        # .spec file is located in tools/packaging directory
+        project_root = Path(__file__).parent.parent.parent
+        self.spec_file = project_root / "tools" / "packaging" / "kumihan_formatter.spec"
         self.exe_name = "Kumihan-Formatter.exe"
 
     def check_dependencies(self) -> bool:


### PR DESCRIPTION
## Summary
- Windows ビルドテストで .spec ファイルが見つからない問題を修正

## Changes
- `scripts/build/build_windows.py`: spec_file パスを正しい場所に修正
  - 変更前: `scripts/build/kumihan_formatter.spec`
  - 変更後: `tools/packaging/kumihan_formatter.spec`

## Problem
GitHub Actions の Windows ビルドテストで以下のエラーが発生：
```
FileNotFoundError: Spec file not found: D:\a\Kumihan-Formatter\Kumihan-Formatter\scripts\build\kumihan_formatter.spec
```

## Solution
- .spec ファイルは `tools/packaging/` ディレクトリにある
- Windows ビルドスクリプトのパスを修正
- macOS ビルドスクリプトは既に正しいパスを使用

## Test plan
- [ ] Windows ビルドテストが通ることを確認
- [ ] macOS ビルドに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)