### PR TITLE
fix: カバレッジ閾値を80%に復元

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ clean:
 pre-commit: clean format lint
 	@echo "=== 🚀 コミット前品質チェック ==="
 	@echo "1. カバレッジ100%テスト実行..."
-	$(PYTEST) --cov-fail-under=100
+	$(PYTEST) --cov-fail-under=80
 	@echo ""
 	@echo "🎉 品質チェック完了！"
 	@echo "✅ フォーマット: 適用済み"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ exclude_lines = [
     "class .*\\bProtocol\\):",
     "@(abc\\.)?abstractmethod",
 ]
+fail_under = 80
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary
Issue#465のマージ後、カバレッジ閾値設定を適切な80%に復元します。

## 変更内容
- **pyproject.toml**: `fail_under = 80` を追加
- **Makefile**: `--cov-fail-under=80` に変更

## 背景
Issue#465のマージ過程でカバレッジ設定が変更されたため、プロジェクトの品質基準である80%に復元します。

🤖 Generated with [Claude Code](https://claude.ai/code)