### PR TITLE
feat: Issue #476 Phase 2 GUI分割 - MVCパターンでの構造改善

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,7 +47,9 @@ jobs:
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
-            このプルリクエストをレビューして、以下の観点でフィードバックをお願いします：
+            **重要**: 必ず日本語でレビューコメントを作成してください。
+
+            このプルリクエストをレビューして、以下の観点で日本語でフィードバックをお願いします：
             - コードの品質とベストプラクティス
             - 潜在的なバグや問題
             - パフォーマンスの考慮事項
@@ -55,7 +57,11 @@ jobs:
             - テストカバレッジ
             - プロジェクトのCLAUDE.mdガイドラインへの準拠
 
-            建設的で役立つフィードバックを心がけてください。
+            建設的で役立つフィードバックを日本語で心がけてください。
+            回答は全て日本語で行い、英語は使用しないでください。
+
+            <language>Japanese</language>
+            <character_code>UTF-8</character_code>
 
           # Use sticky comments to reduce comment proliferation
           use_sticky_comment: true

--- a/kumihan_formatter/gui_controller.py
+++ b/kumihan_formatter/gui_controller.py
@@ -1,0 +1,397 @@
+"""GUI Controller for Kumihan-Formatter
+
+Controller層: イベント制御とビジネスロジック調整
+MVCパターンでのController部分を担当し、ModelとViewの橋渡しを行う
+"""
+
+import platform
+import subprocess
+import sys
+import threading
+import webbrowser
+from pathlib import Path
+from tkinter import filedialog, messagebox
+from typing import TYPE_CHECKING, Any, Optional
+
+from .gui_models import AppState
+from .gui_views import MainView
+
+if TYPE_CHECKING:
+    from .core.log_viewer import LogViewerWindow
+
+# デバッグロガーのインポート
+try:
+    from .core.debug_logger import (
+        debug,
+        error,
+        info,
+        is_debug_enabled,
+        log_gui_event,
+        log_gui_method,
+        warning,
+    )
+except ImportError:
+    # Fallbacksを定義
+    def debug(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    def info(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    def warning(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    def error(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    def log_gui_event(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    def log_gui_method(func: Any) -> Any:  # type: ignore[misc]
+        return func
+
+    def is_debug_enabled() -> bool:
+        return False
+
+
+# コマンドクラスのインポート
+try:
+    from .commands.convert.convert_command import ConvertCommand
+    from .commands.sample import SampleCommand
+except ImportError:
+    try:
+        from kumihan_formatter.commands.convert.convert_command import ConvertCommand
+        from kumihan_formatter.commands.sample import SampleCommand
+    except ImportError as e:
+        error(f"Failed to import command classes: {e}")
+        ConvertCommand = None  # type: ignore
+        SampleCommand = None  # type: ignore
+
+
+class GuiController:
+    """GUIコントローラークラス
+
+    ユーザーインタラクション、イベント処理、ビジネスロジックを管理
+    """
+
+    def __init__(self) -> None:
+        """コントローラーの初期化"""
+        self.app_state = AppState()
+        self.main_view = MainView(self.app_state)
+        self.log_viewer: Optional["LogViewerWindow"] = None
+
+        # イベントハンドラーの設定
+        self._setup_event_handlers()
+
+        # 初期ログメッセージ
+        self._add_startup_messages()
+
+    def _setup_event_handlers(self) -> None:
+        """イベントハンドラーの設定"""
+        # ファイル選択イベント
+        self.main_view.file_selection_frame.set_input_browse_command(
+            self.browse_input_file
+        )
+        self.main_view.file_selection_frame.set_output_browse_command(
+            self.browse_output_dir
+        )
+
+        # オプション変更イベント
+        self.main_view.options_frame.set_source_toggle_command(
+            self.on_source_toggle_change
+        )
+
+        # アクションボタンイベント
+        self.main_view.action_button_frame.set_convert_command(self.convert_file)
+        self.main_view.action_button_frame.set_sample_command(self.generate_sample)
+        self.main_view.action_button_frame.set_help_command(self.show_help)
+        self.main_view.action_button_frame.set_exit_command(self.exit_application)
+
+        # デバッグモード時のログボタン
+        if self.app_state.debug_mode:
+            self.main_view.action_button_frame.set_log_command(self.show_log_viewer)
+
+    def _add_startup_messages(self) -> None:
+        """起動時のメッセージを追加"""
+        self.main_view.log_frame.add_message("Kumihan-Formatter GUI が起動しました")
+        self.main_view.log_frame.add_message(
+            "使い方がわからない場合は「ヘルプ」ボタンをクリックしてください"
+        )
+
+    def browse_input_file(self) -> None:
+        """入力ファイルの参照"""
+        log_gui_event("button_click", "browse_input_file")
+
+        filename = filedialog.askopenfilename(
+            title="変換するテキストファイルを選択",
+            filetypes=[("テキストファイル", "*.txt"), ("すべてのファイル", "*.*")],
+        )
+
+        if filename:
+            info(f"Input file selected: {filename}")
+            self.app_state.config.set_input_file(filename)
+            self.main_view.log_frame.add_message(f"入力ファイル: {Path(filename).name}")
+        else:
+            debug("Input file selection cancelled")
+
+    def browse_output_dir(self) -> None:
+        """出力ディレクトリの参照"""
+        log_gui_event("button_click", "browse_output_dir")
+
+        dirname = filedialog.askdirectory(title="出力フォルダを選択")
+        if dirname:
+            self.app_state.config.set_output_dir(dirname)
+            self.main_view.log_frame.add_message(f"出力フォルダ: {dirname}")
+
+    def on_source_toggle_change(self) -> None:
+        """ソース表示オプションの変更処理"""
+        include_source = self.app_state.config.get_include_source()
+
+        # テンプレートの自動切り替え
+        if include_source:
+            self.app_state.config.set_template("base-with-source-toggle.html.j2")
+            self.main_view.log_frame.add_message("ソース表示機能が有効になりました")
+        else:
+            self.app_state.config.set_template("base.html.j2")
+            self.main_view.log_frame.add_message("ソース表示機能が無効になりました")
+
+    def convert_file(self) -> None:
+        """ファイル変換の実行"""
+        log_gui_event("button_click", "convert_file")
+
+        # 変換準備チェック
+        is_ready, message = self.app_state.is_ready_for_conversion()
+        if not is_ready:
+            messagebox.showerror("エラー", message)
+            return
+
+        # UI無効化
+        self.main_view.set_ui_enabled(False)
+
+        # 変換スレッド開始
+        thread = threading.Thread(target=self._convert_file_thread)
+        thread.daemon = True
+        thread.start()
+
+    def _convert_file_thread(self) -> None:
+        """ファイル変換スレッド"""
+        try:
+            self.main_view.log_frame.add_message("変換を開始します...")
+            self.app_state.conversion_state.update_progress(0, "変換準備中...")
+
+            # 変換パラメータ取得
+            params = self.app_state.config.get_conversion_params()
+            self.app_state.conversion_state.update_progress(20, "設定を読み込み中...")
+
+            # 変換実行
+            if ConvertCommand is None:
+                raise ImportError("ConvertCommand が利用できません")
+
+            convert_command = ConvertCommand()
+            self.app_state.conversion_state.update_progress(40, "ファイルを変換中...")
+
+            convert_command.execute(**params)
+            self.app_state.conversion_state.update_progress(90, "変換完了...")
+
+            # 成功処理
+            output_path = self.app_state.get_output_file_path()
+            if output_path:
+                self.main_view.log_frame.add_message(
+                    f"変換が完了しました: {output_path}", "success"
+                )
+
+                # プレビュー表示
+                if not self.app_state.config.get_no_preview() and output_path.exists():
+                    self.main_view.log_frame.add_message(
+                        "ブラウザでプレビューを開いています..."
+                    )
+                    webbrowser.open(output_path.resolve().as_uri())
+
+            self.app_state.conversion_state.update_progress(100, "完了")
+
+            # 成功ダイアログ
+            self.main_view.root.after(
+                0,
+                lambda: messagebox.showinfo(
+                    "変換完了",
+                    f"ファイルの変換が完了しました。\n\n出力先: {output_path}",
+                ),
+            )
+
+        except Exception as e:
+            error_msg = str(e)
+            self.main_view.log_frame.add_message(f"変換エラー: {error_msg}", "error")
+            self.main_view.root.after(
+                0,
+                lambda: messagebox.showerror(
+                    "変換エラー", f"変換中にエラーが発生しました:\n\n{error_msg}"
+                ),
+            )
+
+        finally:
+            # UI有効化
+            self.main_view.root.after(0, lambda: self.main_view.set_ui_enabled(True))
+            self.app_state.conversion_state.reset()
+
+    def generate_sample(self) -> None:
+        """サンプル生成の実行"""
+        log_gui_event("button_click", "generate_sample")
+
+        # UI無効化
+        self.main_view.set_ui_enabled(False)
+
+        # サンプル生成スレッド開始
+        thread = threading.Thread(target=self._generate_sample_thread)
+        thread.daemon = True
+        thread.start()
+
+    def _generate_sample_thread(self) -> None:
+        """サンプル生成スレッド"""
+        try:
+            self.main_view.log_frame.add_message(
+                "サンプルファイルの生成を開始します..."
+            )
+            self.app_state.conversion_state.update_progress(0, "サンプル生成準備中...")
+
+            use_source_toggle = self.app_state.config.get_include_source()
+            self.app_state.conversion_state.update_progress(
+                30, "サンプルファイルを作成中..."
+            )
+
+            # サンプル生成実行
+            if SampleCommand is None:
+                raise ImportError("SampleCommand が利用できません")
+
+            sample_command = SampleCommand()
+            output_path = sample_command.execute(
+                output_dir="kumihan_sample", use_source_toggle=use_source_toggle
+            )
+
+            self.app_state.conversion_state.update_progress(80, "サンプル生成完了...")
+
+            self.main_view.log_frame.add_message(
+                f"サンプルファイルが生成されました: {output_path.absolute()}", "success"
+            )
+
+            # サンプルHTMLを開く
+            sample_html = output_path / "showcase.html"
+            if sample_html.exists():
+                self.main_view.log_frame.add_message(
+                    "ブラウザでサンプルを開いています..."
+                )
+                webbrowser.open(sample_html.resolve().as_uri())
+
+            # Finder/Explorerで開く
+            self._open_directory_in_file_manager(output_path)
+
+            self.app_state.conversion_state.update_progress(100, "完了")
+
+            # 成功ダイアログ
+            self.main_view.root.after(
+                0,
+                lambda: messagebox.showinfo(
+                    "サンプル生成完了",
+                    f"サンプルファイルの生成が完了しました。\n\n"
+                    f"出力先: {output_path.absolute()}\n\n"
+                    f"生成されたファイル:\n"
+                    f"• showcase.html (メインHTML)\n"
+                    f"• showcase.txt (ソーステキスト)\n"
+                    f"• images/ (サンプル画像)\n\n"
+                    f"ファイルマネージャーでフォルダを開きました。",
+                ),
+            )
+
+        except Exception as e:
+            import traceback
+
+            error_details = traceback.format_exc()
+            error_msg = str(e)
+            self.main_view.log_frame.add_message(
+                f"サンプル生成エラー: {error_msg}", "error"
+            )
+            self.main_view.log_frame.add_message(f"詳細: {error_details}", "error")
+            self.main_view.root.after(
+                0,
+                lambda: messagebox.showerror(
+                    "サンプル生成エラー",
+                    f"サンプル生成中にエラーが発生しました:\n\n{error_msg}\n\n詳細はログを確認してください。",
+                ),
+            )
+
+        finally:
+            # UI有効化
+            self.main_view.root.after(0, lambda: self.main_view.set_ui_enabled(True))
+            self.app_state.conversion_state.reset()
+
+    def _open_directory_in_file_manager(self, directory_path: Path) -> None:
+        """ファイルマネージャーでディレクトリを開く"""
+        try:
+            system = platform.system()
+            if system == "Darwin":  # macOS
+                self.main_view.log_frame.add_message(
+                    "Finderでフォルダを開いています..."
+                )
+                subprocess.run(["open", str(directory_path.absolute())])
+            elif system == "Windows":
+                self.main_view.log_frame.add_message(
+                    "エクスプローラーでフォルダを開いています..."
+                )
+                subprocess.run(["explorer", str(directory_path.absolute())])
+            elif system == "Linux":
+                self.main_view.log_frame.add_message(
+                    "ファイルマネージャーでフォルダを開いています..."
+                )
+                subprocess.run(["xdg-open", str(directory_path.absolute())])
+        except Exception as e:
+            warning(f"Failed to open directory in file manager: {e}")
+
+    def show_help(self) -> None:
+        """ヘルプダイアログの表示"""
+        log_gui_event("button_click", "show_help")
+        self.main_view.help_dialog.show()
+
+    def show_log_viewer(self) -> None:
+        """ログビューアーの表示（デバッグモード時のみ）"""
+        log_gui_event("button_click", "show_log_viewer")
+
+        try:
+            if self.log_viewer and self.log_viewer.is_open():
+                # 既に開いている場合は前面に表示
+                if hasattr(self.log_viewer, "window") and self.log_viewer.window:
+                    self.log_viewer.window.lift()
+                    self.log_viewer.window.focus_force()
+            else:
+                # 新しいログビューアーを開く
+                from .core.log_viewer import LogViewerWindow
+
+                self.log_viewer = LogViewerWindow(self.main_view.root)
+                self.log_viewer.show()
+                info("Log viewer window opened")
+        except Exception as e:
+            error("Failed to open log viewer", e)
+            messagebox.showerror(
+                "エラー", f"ログビューアーの表示に失敗しました:\n\n{str(e)}"
+            )
+
+    def exit_application(self) -> None:
+        """アプリケーションの終了"""
+        log_gui_event("button_click", "exit_application")
+        self.main_view.root.quit()
+
+    def run(self) -> None:
+        """GUIアプリケーションの実行"""
+        try:
+            info("Starting GUI main loop...")
+            self.main_view.start_mainloop()
+        except Exception as e:
+            error(f"GUI main loop error: {e}")
+            raise
+
+
+def create_gui_application() -> GuiController:
+    """GUIアプリケーションの作成
+
+    Returns:
+        設定済みのGUIコントローラー
+    """
+    return GuiController()

--- a/kumihan_formatter/gui_launcher.py
+++ b/kumihan_formatter/gui_launcher.py
@@ -1,688 +1,107 @@
 """GUI Launcher for Kumihan-Formatter
-Windows向けexe形式パッケージング用のGUIランチャー
 
-This module provides a user-friendly GUI interface for non-technical users
-to use Kumihan-Formatter without command line knowledge.
+エントリーポイント: MVCパターンで再構築されたGUIアプリケーションのランチャー
+最小限のコードでGUIコントローラーを起動し、エラーハンドリングを提供
 """
 
 import sys
-import threading
-import webbrowser
 from pathlib import Path
-from tkinter import *
-from tkinter import filedialog, messagebox, ttk
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import Any
 
-if TYPE_CHECKING:
-    from .core.log_viewer import LogViewerWindow
+# パスの設定
+current_dir = Path(__file__).parent
+if str(current_dir) not in sys.path:
+    sys.path.insert(0, str(current_dir))
 
-# Debug logger (環境変数KUMIHAN_GUI_DEBUG=trueで有効化)
+# デバッグロガーのインポート
 try:
     from .core.debug_logger import (
-        debug,
         error,
-        get_logger,
         info,
-        is_debug_enabled,
-        log_gui_event,
-        log_gui_method,
         log_startup_info,
-        warning,
     )
 except ImportError:
     # Fallback for direct execution
     try:
         from kumihan_formatter.core.debug_logger import (
-            debug,
             error,
-            get_logger,
             info,
-            is_debug_enabled,
-            log_gui_event,
-            log_gui_method,
             log_startup_info,
-            warning,
         )
     except ImportError:
-        # No-op fallbacks if debug logger is not available
-
-        def debug(*args: Any, **kwargs: Any) -> None:
-            pass
-
+        # No-op fallbacks
         def info(*args: Any, **kwargs: Any) -> None:
-            pass
-
-        def warning(*args: Any, **kwargs: Any) -> None:
             pass
 
         def error(*args: Any, **kwargs: Any) -> None:
             pass
 
-        def log_gui_event(*args: Any, **kwargs: Any) -> None:
-            pass
-
-        def log_gui_method(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[misc]
-            return func
-
         def log_startup_info() -> None:
             pass
 
-        def is_debug_enabled() -> bool:
-            return False
 
-        def get_logger() -> Any:  # type: ignore[misc]
-            return None
-
-
-# Log startup information
+# スタートアップ情報のログ
 log_startup_info()
 info("GUI Launcher module loading...")
 
-# Add the parent directory to sys.path to import kumihan_formatter modules
-current_dir = Path(__file__).parent
-if str(current_dir) not in sys.path:
-    sys.path.insert(0, str(current_dir))
-
-# Try relative imports first (for package execution)
-info("Attempting to import required modules...")
+# GUIコントローラーのインポート
 try:
-    debug("Trying relative imports...")
-    from .commands.convert.convert_command import ConvertCommand
-    from .commands.sample import SampleCommand
-    from .core.config.config_manager import EnhancedConfig
-    from .ui.console_ui import get_console_ui
+    info("Importing GUI controller...")
+    from .gui_controller import create_gui_application
 
-    info("Relative imports successful")
-except ImportError as relative_error:
-    warning(f"Relative imports failed: {relative_error}")
-    # Try absolute imports (for direct execution)
+    info("GUI controller imported successfully")
+except ImportError as gui_error:
+    error(f"Failed to import GUI controller: {gui_error}")
+    # 詳細なエラー情報を表示
+    import traceback
+
+    error(f"Import traceback: {traceback.format_exc()}")
+
+    # フォールバック: エラーダイアログを表示して終了
     try:
-        debug("Trying absolute imports...")
-        from kumihan_formatter.commands.convert.convert_command import ConvertCommand
-        from kumihan_formatter.commands.sample import SampleCommand
-        from kumihan_formatter.core.config.config_manager import EnhancedConfig
-        from kumihan_formatter.ui.console_ui import get_console_ui
-
-        info("Absolute imports successful")
-    except ImportError as absolute_error:
-        # If both fail, show detailed error and exit
-        import sys
-
-        error_msg = f"インポートエラー: 必要なモジュールが見つかりません"
-        error(error_msg)
-        error(f"相対インポートエラー: {relative_error}")
-        error(f"絶対インポートエラー: {absolute_error}")
-        error(f"現在のPythonパス: {sys.path}")
-
-        print(error_msg, file=sys.stderr)
-        print(f"相対インポートエラー: {relative_error}", file=sys.stderr)
-        print(f"絶対インポートエラー: {absolute_error}", file=sys.stderr)
-        print(f"現在のPythonパス: {sys.path}", file=sys.stderr)
-        if is_debug_enabled():
-            print(
-                f"デバッグログファイル: {get_logger().get_log_file_path()}",
-                file=sys.stderr,
-            )
-        sys.exit(1)
-
-
-class KumihanGUI:
-    """Main GUI application class for Kumihan-Formatter"""
-
-    @log_gui_method  # type: ignore
-    def __init__(self) -> None:
-        info("Initializing KumihanGUI...")
-        try:
-            debug("Creating root Tk window...")
-            self.root = Tk()
-            self.root.title("Kumihan-Formatter v1.0 - 美しい組版を、誰でも簡単に")
-            self.root.geometry("800x600")
-            self.root.resizable(True, True)
-            info("Root Tk window created successfully")
-        except Exception as e:
-            error("Failed to create root Tk window", e)
-            raise
-
-        # Configure style
-        try:
-            debug("Configuring ttk style...")
-            self.style = ttk.Style()
-            self.style.theme_use("clam")
-            info("ttk style configured successfully")
-        except Exception as e:
-            error("Failed to configure ttk style", e)
-            raise
-
-        # Variables
-        self.input_file_var = StringVar()
-        self.output_dir_var = StringVar(value="./dist")
-        self.template_var = StringVar(value="base.html.j2")
-        self.include_source_var = BooleanVar(value=False)
-        self.no_preview_var = BooleanVar(value=False)
-
-        # Progress tracking
-        self.progress_var = DoubleVar()
-        self.status_var = StringVar(value="準備完了")
-
-        try:
-            debug("Setting up UI components...")
-            self.setup_ui()
-            info("UI components setup completed")
-
-            debug("Centering window...")
-            self.center_window()
-            info("Window centered")
-
-            info("KumihanGUI initialization completed successfully")
-        except Exception as e:
-            error("Failed during GUI initialization", e)
-            raise
-
-    def setup_ui(self) -> None:
-        """Setup the main UI components"""
-        # Main container
-        main_frame = ttk.Frame(self.root, padding="10")
-        main_frame.grid(row=0, column=0, sticky="WENS")
-
-        # Configure grid weights
-        self.root.columnconfigure(0, weight=1)
-        self.root.rowconfigure(0, weight=1)
-        main_frame.columnconfigure(1, weight=1)
-
-        # Title
-        title_label = ttk.Label(
-            main_frame, text="Kumihan-Formatter", font=("Arial", 16, "bold")
-        )
-        title_label.grid(row=0, column=0, columnspan=3, pady=(0, 20))
-
-        subtitle_label = ttk.Label(
-            main_frame,
-            text="美しい組版を、誰でも簡単に。テキストファイルをワンクリックでHTMLに変換",
-            font=("Arial", 10),
-        )
-        subtitle_label.grid(row=1, column=0, columnspan=3, pady=(0, 20))
-
-        # File selection section
-        file_frame = ttk.LabelFrame(main_frame, text="ファイル選択", padding="10")
-        file_frame.grid(row=2, column=0, columnspan=3, sticky="WE", pady=(0, 10))
-        file_frame.columnconfigure(1, weight=1)
-
-        ttk.Label(file_frame, text="入力ファイル:").grid(
-            row=0, column=0, sticky=W, padx=(0, 10)
-        )
-        ttk.Entry(file_frame, textvariable=self.input_file_var, width=50).grid(
-            row=0, column=1, sticky="WE", padx=(0, 10)
-        )
-        ttk.Button(file_frame, text="参照", command=self.browse_input_file).grid(  # type: ignore[misc]
-            row=0, column=2
-        )
-
-        ttk.Label(file_frame, text="出力フォルダ:").grid(
-            row=1, column=0, sticky=W, padx=(0, 10), pady=(10, 0)
-        )
-        ttk.Entry(file_frame, textvariable=self.output_dir_var, width=50).grid(
-            row=1, column=1, sticky="WE", padx=(0, 10), pady=(10, 0)
-        )
-        ttk.Button(file_frame, text="参照", command=self.browse_output_dir).grid(
-            row=1, column=2, pady=(10, 0)
-        )
-
-        # Options section
-        options_frame = ttk.LabelFrame(main_frame, text="変換オプション", padding="10")
-        options_frame.grid(row=3, column=0, columnspan=3, sticky="WE", pady=(0, 10))
-        options_frame.columnconfigure(1, weight=1)
-
-        ttk.Label(options_frame, text="テンプレート:").grid(
-            row=0, column=0, sticky=W, padx=(0, 10)
-        )
-        template_combo = ttk.Combobox(
-            options_frame,
-            textvariable=self.template_var,
-            values=["base.html.j2", "base-with-source-toggle.html.j2"],
-            state="readonly",
-        )
-        template_combo.grid(row=0, column=1, sticky="WE", padx=(0, 10))
-
-        ttk.Checkbutton(
-            options_frame,
-            text="ソース表示機能を含める",
-            variable=self.include_source_var,
-            command=self.on_source_toggle_change,
-        ).grid(row=1, column=0, columnspan=2, sticky=W, pady=(10, 0))
-
-        ttk.Checkbutton(
-            options_frame,
-            text="変換後のプレビューをスキップ",
-            variable=self.no_preview_var,
-        ).grid(row=2, column=0, columnspan=2, sticky=W, pady=(5, 0))
-
-        # Action buttons
-        button_frame = ttk.Frame(main_frame)
-        button_frame.grid(row=4, column=0, columnspan=3, pady=20)
-
-        ttk.Button(
-            button_frame,
-            text="変換実行",
-            command=self.convert_file,
-            style="Accent.TButton",
-        ).pack(side=LEFT, padx=(0, 10))
-
-        ttk.Button(
-            button_frame, text="サンプル生成", command=self.generate_sample
-        ).pack(side=LEFT, padx=(0, 10))
-
-        ttk.Button(button_frame, text="ヘルプ", command=self.show_help).pack(
-            side=LEFT, padx=(0, 10)
-        )
-
-        # デバッグモードの時のみログビューアーボタンを表示
-        if is_debug_enabled():
-            ttk.Button(button_frame, text="ログ", command=self.show_log_viewer).pack(  # type: ignore[misc]
-                side=LEFT, padx=(0, 10)
-            )
-
-        ttk.Button(button_frame, text="終了", command=self.root.quit).pack(side=LEFT)
-
-        # Progress section
-        progress_frame = ttk.LabelFrame(main_frame, text="進行状況", padding="10")
-        progress_frame.grid(row=5, column=0, columnspan=3, sticky="WE", pady=(0, 10))
-        progress_frame.columnconfigure(0, weight=1)
-
-        self.progress_bar = ttk.Progressbar(
-            progress_frame, variable=self.progress_var, maximum=100
-        )
-        self.progress_bar.grid(row=0, column=0, sticky="WE", pady=(0, 5))
-
-        self.status_label = ttk.Label(progress_frame, textvariable=self.status_var)
-        self.status_label.grid(row=1, column=0, sticky=W)
-
-        # ログビューアーの参照を保持
-        self.log_viewer: Optional["LogViewerWindow"] = None
-
-        # Log section
-        log_frame = ttk.LabelFrame(main_frame, text="ログ", padding="10")
-        log_frame.grid(row=6, column=0, columnspan=3, sticky="WENS", pady=(0, 10))
-        log_frame.columnconfigure(0, weight=1)
-        log_frame.rowconfigure(0, weight=1)
-        main_frame.rowconfigure(6, weight=1)
-
-        self.log_text = Text(log_frame, height=8, wrap=WORD, state=DISABLED)
-        log_scrollbar = ttk.Scrollbar(
-            log_frame, orient=VERTICAL, command=self.log_text.yview
-        )
-        self.log_text.configure(yscrollcommand=log_scrollbar.set)
-
-        self.log_text.grid(row=0, column=0, sticky="WENS")
-        log_scrollbar.grid(row=0, column=1, sticky="NS")
-
-    def center_window(self) -> None:
-        """Center the window on screen"""
-        self.root.update_idletasks()
-        width = self.root.winfo_width()
-        height = self.root.winfo_height()
-        pos_x = (self.root.winfo_screenwidth() // 2) - (width // 2)
-        pos_y = (self.root.winfo_screenheight() // 2) - (height // 2)
-        self.root.geometry(f"{width}x{height}+{pos_x}+{pos_y}")
-
-    @log_gui_method  # type: ignore
-    def browse_input_file(self) -> None:
-        """Browse for input file"""
-        log_gui_event("button_click", "browse_input_file")
-        filename = filedialog.askopenfilename(
-            title="変換するテキストファイルを選択",
-            filetypes=[("テキストファイル", "*.txt"), ("すべてのファイル", "*.*")],
-        )
-        if filename:
-            info(f"Input file selected: {filename}")
-            self.input_file_var.set(filename)
-        else:
-            debug("Input file selection cancelled")
-
-    def browse_output_dir(self) -> None:
-        """Browse for output directory"""
-        dirname = filedialog.askdirectory(title="出力フォルダを選択")
-        if dirname:
-            self.output_dir_var.set(dirname)
-
-    def on_source_toggle_change(self) -> None:
-        """Handle source toggle checkbox change"""
-        if self.include_source_var.get():
-            self.template_var.set("base-with-source-toggle.html.j2")
-        else:
-            self.template_var.set("base.html.j2")
-
-    def log_message(self, message: str, level: str = "info") -> None:
-        """Add message to log"""
-        self.log_text.config(state=NORMAL)
-        timestamp = __import__("datetime").datetime.now().strftime("%H:%M:%S")
-
-        if level == "error":
-            prefix = "❌"
-        elif level == "success":
-            prefix = "✅"
-        elif level == "warning":
-            prefix = "⚠️"
-        else:
-            prefix = "ℹ️"
-
-        self.log_text.insert(END, f"[{timestamp}] {prefix} {message}\n")
-        self.log_text.config(state=DISABLED)
-        self.log_text.see(END)
-        self.root.update_idletasks()
-
-    def update_progress(self, value: float, status: str = "") -> None:
-        """Update progress bar and status"""
-        self.progress_var.set(value)
-        if status:
-            self.status_var.set(status)
-        self.root.update_idletasks()
-
-    def convert_file(self) -> None:
-        """Execute file conversion in separate thread"""
-        input_file = self.input_file_var.get().strip()
-        if not input_file:
-            messagebox.showerror("エラー", "入力ファイルを選択してください。")
-            return
-
-        if not Path(input_file).exists():
-            messagebox.showerror("エラー", "指定されたファイルが見つかりません。")
-            return
-
-        # Disable UI elements during conversion
-        self.set_ui_enabled(False)
-
-        # Start conversion in separate thread
-        thread = threading.Thread(target=self._convert_file_thread)
-        thread.daemon = True
-        thread.start()
-
-    def _convert_file_thread(self) -> None:
-        """File conversion thread"""
-        try:
-            self.log_message("変換を開始します...")
-            self.update_progress(0, "変換準備中...")
-
-            input_file = self.input_file_var.get()
-            output_dir = self.output_dir_var.get()
-            template = self.template_var.get()
-            include_source = self.include_source_var.get()
-            no_preview = self.no_preview_var.get()
-
-            self.update_progress(20, "設定を読み込み中...")
-
-            # Execute conversion
-            try:
-                convert_command = ConvertCommand()
-                self.update_progress(40, "ファイルを変換中...")
-
-                # Execute conversion with GUI-friendly parameters
-                convert_command.execute(
-                    input_file=input_file,
-                    output=output_dir,
-                    no_preview=no_preview,
-                    watch=False,
-                    config=None,
-                    show_test_cases=False,
-                    template_name=template,
-                    include_source=include_source,
-                    syntax_check=True,
-                )
-
-                self.update_progress(90, "変換完了...")
-
-                # Success message
-                output_path = Path(output_dir) / f"{Path(input_file).stem}.html"
-                self.log_message(f"変換が完了しました: {output_path}", "success")
-
-                if not no_preview and output_path.exists():
-                    self.log_message("ブラウザでプレビューを開いています...")
-                    webbrowser.open(output_path.resolve().as_uri())
-
-                self.update_progress(100, "完了")
-
-                # Show success dialog
-                self.root.after(
-                    0,
-                    lambda: messagebox.showinfo(
-                        "変換完了",
-                        f"ファイルの変換が完了しました。\n\n出力先: {output_path}",
-                    ),
-                )
-
-            except Exception as e:
-                self.log_message(f"変換エラー: {str(e)}", "error")
-                self.root.after(
-                    0,
-                    lambda: messagebox.showerror(
-                        "変換エラー", f"変換中にエラーが発生しました:\n\n{str(e)}"
-                    ),
-                )
-
-        except Exception as e:
-            self.log_message(f"予期しないエラー: {str(e)}", "error")
-            self.root.after(
-                0,
-                lambda: messagebox.showerror(
-                    "エラー", f"予期しないエラーが発生しました:\n\n{str(e)}"
-                ),
-            )
-
-        finally:
-            # Re-enable UI
-            self.root.after(0, lambda: self.set_ui_enabled(True))
-            self.update_progress(0, "準備完了")
-
-    def generate_sample(self) -> None:
-        """Generate sample files in separate thread"""
-        # Disable UI elements during generation
-        self.set_ui_enabled(False)
-
-        # Start generation in separate thread
-        thread = threading.Thread(target=self._generate_sample_thread)
-        thread.daemon = True
-        thread.start()
-
-    def _generate_sample_thread(self) -> None:
-        """Sample generation thread"""
-        try:
-            self.log_message("サンプルファイルの生成を開始します...")
-            self.update_progress(0, "サンプル生成準備中...")
-
-            use_source_toggle = self.include_source_var.get()
-
-            self.update_progress(30, "サンプルファイルを作成中...")
-
-            # Execute sample generation
-            try:
-                sample_command = SampleCommand()
-            except Exception as init_error:
-                self.log_message(
-                    f"SampleCommandの初期化エラー: {str(init_error)}", "error"
-                )
-                raise init_error
-
-            output_path = sample_command.execute(
-                output_dir="kumihan_sample", use_source_toggle=use_source_toggle
-            )
-
-            self.update_progress(80, "サンプル生成完了...")
-
-            self.log_message(
-                f"サンプルファイルが生成されました: {output_path.absolute()}", "success"
-            )
-
-            # Open sample HTML
-            sample_html = output_path / "showcase.html"
-            if sample_html.exists():
-                self.log_message("ブラウザでサンプルを開いています...")
-                webbrowser.open(sample_html.resolve().as_uri())
-
-            # Open directory in Finder (macOS)
-            import platform
-            import subprocess
-
-            if platform.system() == "Darwin":  # macOS
-                self.log_message("Finderでフォルダを開いています...")
-                subprocess.run(["open", str(output_path.absolute())])
-
-            self.update_progress(100, "完了")
-
-            # Show success dialog with more detail
-            self.root.after(
-                0,
-                lambda: messagebox.showinfo(
-                    "サンプル生成完了",
-                    f"サンプルファイルの生成が完了しました。\n\n"
-                    f"出力先: {output_path.absolute()}\n\n"
-                    f"生成されたファイル:\n"
-                    f"• showcase.html (メインHTML)\n"
-                    f"• showcase.txt (ソーステキスト)\n"
-                    f"• images/ (サンプル画像)\n\n"
-                    f"Finderでフォルダを開きました。",
-                ),
-            )
-
-        except Exception as e:
-            import traceback
-
-            error_details = traceback.format_exc()
-            self.log_message(f"サンプル生成エラー: {str(e)}", "error")
-            self.log_message(f"詳細: {error_details}", "error")
-            self.root.after(
-                0,
-                lambda: messagebox.showerror(
-                    "サンプル生成エラー",
-                    f"サンプル生成中にエラーが発生しました:\n\n{str(e)}\n\n詳細はログを確認してください。",
-                ),
-            )
-
-        finally:
-            # Re-enable UI
-            self.root.after(0, lambda: self.set_ui_enabled(True))
-            self.update_progress(0, "準備完了")
-
-    def set_ui_enabled(self, enabled: bool) -> None:
-        """Enable/disable UI elements"""
-        state = NORMAL if enabled else DISABLED
-
-        # Find all widgets and update their state
-        def update_widget_state(widget) -> None:  # type: ignore
-            try:
-                if isinstance(
-                    widget, (ttk.Button, ttk.Entry, ttk.Combobox, ttk.Checkbutton)
-                ):
-                    widget.configure(state=state)
-            except:
-                pass
-
-            for child in widget.winfo_children():
-                update_widget_state(child)
-
-        update_widget_state(self.root)
-
-    def show_help(self) -> None:
-        """Show help dialog"""
-        help_text = """Kumihan-Formatter GUI ヘルプ
-
-【基本的な使い方】
-1. 「参照」ボタンから変換したいテキストファイルを選択
-2. 出力フォルダを指定（デフォルト: ./dist）
-3. 必要に応じてオプションを設定
-4. 「変換実行」ボタンをクリック
-
-【オプション説明】
-• テンプレート: 出力HTMLのテンプレートを選択
-• ソース表示機能: 原文と変換結果を切り替え表示する機能
-• プレビューをスキップ: 変換後にブラウザを自動で開かない
-
-【サンプル生成】
-「サンプル生成」ボタンで機能紹介用のサンプルファイルを生成できます。
-
-【サポート】
-詳細な使い方やトラブルシューティングは、
-プロジェクトのドキュメントを参照してください。
-
-GitHub: https://github.com/mo9mo9-uwu-mo9mo9/Kumihan-Formatter
-"""
-
-        help_window = Toplevel(self.root)
-        help_window.title("ヘルプ")
-        help_window.geometry("600x500")
-        help_window.transient(self.root)
-        help_window.grab_set()
-
-        # Center help window
-        help_window.update_idletasks()
-        x = (help_window.winfo_screenwidth() // 2) - (600 // 2)
-        y = (help_window.winfo_screenheight() // 2) - (500 // 2)
-        help_window.geometry(f"600x500+{x}+{y}")
-
-        # Help content
-        text_frame = Frame(help_window)
-        text_frame.pack(fill=BOTH, expand=True, padx=20, pady=20)
-
-        help_text_widget = Text(text_frame, wrap=WORD, padx=10, pady=10)
-        help_scrollbar = ttk.Scrollbar(
-            text_frame, orient=VERTICAL, command=help_text_widget.yview
-        )
-        help_text_widget.configure(yscrollcommand=help_scrollbar.set)
-
-        help_text_widget.pack(side=LEFT, fill=BOTH, expand=True)
-        help_scrollbar.pack(side=RIGHT, fill=Y)
-
-        help_text_widget.insert("1.0", help_text)
-        help_text_widget.config(state=DISABLED)
-
-        # Close button
-        ttk.Button(help_window, text="閉じる", command=help_window.destroy).pack(
-            pady=10
-        )
-
-    @log_gui_method  # type: ignore
-    def show_log_viewer(self) -> None:
-        """Show debug log viewer window"""
-        log_gui_event("button_click", "show_log_viewer")
-        try:
-            if self.log_viewer and self.log_viewer.is_open():
-                # 既に開いている場合は前面に表示
-                if self.log_viewer.window:
-                    self.log_viewer.window.lift()
-                    self.log_viewer.window.focus_force()
-            else:
-                # 新しいログビューアーを開く
-                from .core.log_viewer import LogViewerWindow
-
-                self.log_viewer = LogViewerWindow(self.root)
-                self.log_viewer.show()
-                info("Log viewer window opened")
-        except Exception as e:
-            error("Failed to open log viewer", e)
-            messagebox.showerror(
-                "エラー", f"ログビューアーの表示に失敗しました:\n\n{str(e)}"
-            )
-
-    def run(self) -> None:
-        """Start the GUI application"""
-        self.log_message("Kumihan-Formatter GUI が起動しました")
-        self.log_message(
-            "使い方がわからない場合は「ヘルプ」ボタンをクリックしてください"
-        )
-        self.root.mainloop()
-
-
-def main() -> None:
-    """Main entry point for GUI launcher"""
-    try:
-        app = KumihanGUI()
-        app.run()
-    except Exception as e:
-        # Fallback error handling for GUI startup issues
         import tkinter.messagebox as mb
 
         mb.showerror(
-            "起動エラー",
-            f"GUIの起動中にエラーが発生しました:\n\n{str(e)}\n\nコマンドライン版の使用をお試しください。",
+            "インポートエラー",
+            f"GUIコンポーネントの読み込みに失敗しました:\n\n{gui_error}\n\n"
+            f"必要なモジュールがインストールされているか確認してください。",
         )
+    except Exception:
+        print(
+            f"GUIコンポーネントの読み込みに失敗しました: {gui_error}", file=sys.stderr
+        )
+
+    sys.exit(1)
+
+
+def main() -> None:
+    """メイン関数: GUIアプリケーションのエントリーポイント"""
+    try:
+        info("Creating GUI application...")
+        app = create_gui_application()
+
+        info("Starting GUI application...")
+        app.run()
+
+        info("GUI application finished")
+
+    except Exception as e:
+        error(f"GUI application error: {e}")
+
+        # エラーダイアログの表示
+        try:
+            import tkinter.messagebox as mb
+
+            mb.showerror(
+                "起動エラー",
+                f"GUIの起動中にエラーが発生しました:\n\n{str(e)}\n\n"
+                f"コマンドライン版の使用をお試しください。",
+            )
+        except Exception:
+            # Tkinterも利用できない場合はコンソールに出力
+            print(f"GUIの起動中にエラーが発生しました: {str(e)}", file=sys.stderr)
+            print("コマンドライン版の使用をお試しください。", file=sys.stderr)
+
         sys.exit(1)
 
 

--- a/kumihan_formatter/gui_launcher_backup.py
+++ b/kumihan_formatter/gui_launcher_backup.py
@@ -1,0 +1,690 @@
+"""GUI Launcher for Kumihan-Formatter
+Windows向けexe形式パッケージング用のGUIランチャー
+
+This module provides a user-friendly GUI interface for non-technical users
+to use Kumihan-Formatter without command line knowledge.
+"""
+
+import sys
+import threading
+import webbrowser
+from pathlib import Path
+from tkinter import *
+from tkinter import filedialog, messagebox, ttk
+from typing import TYPE_CHECKING, Any, Callable, Optional
+
+if TYPE_CHECKING:
+    from .core.log_viewer import LogViewerWindow
+
+# Debug logger (環境変数KUMIHAN_GUI_DEBUG=trueで有効化)
+try:
+    from .core.debug_logger import (
+        debug,
+        error,
+        get_logger,
+        info,
+        is_debug_enabled,
+        log_gui_event,
+        log_gui_method,
+        log_startup_info,
+        warning,
+    )
+except ImportError:
+    # Fallback for direct execution
+    try:
+        from kumihan_formatter.core.debug_logger import (
+            debug,
+            error,
+            get_logger,
+            info,
+            is_debug_enabled,
+            log_gui_event,
+            log_gui_method,
+            log_startup_info,
+            warning,
+        )
+    except ImportError:
+        # No-op fallbacks if debug logger is not available
+
+        def debug(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        def info(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        def warning(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        def error(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        def log_gui_event(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        def log_gui_method(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[misc]
+            return func
+
+        def log_startup_info() -> None:
+            pass
+
+        def is_debug_enabled() -> bool:
+            return False
+
+        def get_logger() -> Any:  # type: ignore[misc]
+            return None
+
+
+# Log startup information
+log_startup_info()
+info("GUI Launcher module loading...")
+
+# Add the parent directory to sys.path to import kumihan_formatter modules
+current_dir = Path(__file__).parent
+if str(current_dir) not in sys.path:
+    sys.path.insert(0, str(current_dir))
+
+# Try relative imports first (for package execution)
+info("Attempting to import required modules...")
+try:
+    debug("Trying relative imports...")
+    from .commands.convert.convert_command import ConvertCommand
+    from .commands.sample import SampleCommand
+    from .core.config.config_manager import EnhancedConfig
+    from .ui.console_ui import get_console_ui
+
+    info("Relative imports successful")
+except ImportError as relative_error:
+    warning(f"Relative imports failed: {relative_error}")
+    # Try absolute imports (for direct execution)
+    try:
+        debug("Trying absolute imports...")
+        from kumihan_formatter.commands.convert.convert_command import ConvertCommand
+        from kumihan_formatter.commands.sample import SampleCommand
+        from kumihan_formatter.core.config.config_manager import EnhancedConfig
+        from kumihan_formatter.ui.console_ui import get_console_ui
+
+        info("Absolute imports successful")
+    except ImportError as absolute_error:
+        # If both fail, show detailed error and exit
+        import sys
+
+        error_msg = f"インポートエラー: 必要なモジュールが見つかりません"
+        error(error_msg)
+        error(f"相対インポートエラー: {relative_error}")
+        error(f"絶対インポートエラー: {absolute_error}")
+        error(f"現在のPythonパス: {sys.path}")
+
+        print(error_msg, file=sys.stderr)
+        print(f"相対インポートエラー: {relative_error}", file=sys.stderr)
+        print(f"絶対インポートエラー: {absolute_error}", file=sys.stderr)
+        print(f"現在のPythonパス: {sys.path}", file=sys.stderr)
+        if is_debug_enabled():
+            print(
+                f"デバッグログファイル: {get_logger().get_log_file_path()}",
+                file=sys.stderr,
+            )
+        sys.exit(1)
+
+
+class KumihanGUI:
+    """Main GUI application class for Kumihan-Formatter"""
+
+    @log_gui_method  # type: ignore
+    def __init__(self) -> None:
+        info("Initializing KumihanGUI...")
+        try:
+            debug("Creating root Tk window...")
+            self.root = Tk()
+            self.root.title("Kumihan-Formatter v1.0 - 美しい組版を、誰でも簡単に")
+            self.root.geometry("800x600")
+            self.root.resizable(True, True)
+            info("Root Tk window created successfully")
+        except Exception as e:
+            error("Failed to create root Tk window", e)
+            raise
+
+        # Configure style
+        try:
+            debug("Configuring ttk style...")
+            self.style = ttk.Style()
+            self.style.theme_use("clam")
+            info("ttk style configured successfully")
+        except Exception as e:
+            error("Failed to configure ttk style", e)
+            raise
+
+        # Variables
+        self.input_file_var = StringVar()
+        self.output_dir_var = StringVar(value="./dist")
+        self.template_var = StringVar(value="base.html.j2")
+        self.include_source_var = BooleanVar(value=False)
+        self.no_preview_var = BooleanVar(value=False)
+
+        # Progress tracking
+        self.progress_var = DoubleVar()
+        self.status_var = StringVar(value="準備完了")
+
+        try:
+            debug("Setting up UI components...")
+            self.setup_ui()
+            info("UI components setup completed")
+
+            debug("Centering window...")
+            self.center_window()
+            info("Window centered")
+
+            info("KumihanGUI initialization completed successfully")
+        except Exception as e:
+            error("Failed during GUI initialization", e)
+            raise
+
+    def setup_ui(self) -> None:
+        """Setup the main UI components"""
+        # Main container
+        main_frame = ttk.Frame(self.root, padding="10")
+        main_frame.grid(row=0, column=0, sticky="WENS")
+
+        # Configure grid weights
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(0, weight=1)
+        main_frame.columnconfigure(1, weight=1)
+
+        # Title
+        title_label = ttk.Label(
+            main_frame, text="Kumihan-Formatter", font=("Arial", 16, "bold")
+        )
+        title_label.grid(row=0, column=0, columnspan=3, pady=(0, 20))
+
+        subtitle_label = ttk.Label(
+            main_frame,
+            text="美しい組版を、誰でも簡単に。テキストファイルをワンクリックでHTMLに変換",
+            font=("Arial", 10),
+        )
+        subtitle_label.grid(row=1, column=0, columnspan=3, pady=(0, 20))
+
+        # File selection section
+        file_frame = ttk.LabelFrame(main_frame, text="ファイル選択", padding="10")
+        file_frame.grid(row=2, column=0, columnspan=3, sticky="WE", pady=(0, 10))
+        file_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(file_frame, text="入力ファイル:").grid(
+            row=0, column=0, sticky=W, padx=(0, 10)
+        )
+        ttk.Entry(file_frame, textvariable=self.input_file_var, width=50).grid(
+            row=0, column=1, sticky="WE", padx=(0, 10)
+        )
+        ttk.Button(file_frame, text="参照", command=self.browse_input_file).grid(  # type: ignore[misc]
+            row=0, column=2
+        )
+
+        ttk.Label(file_frame, text="出力フォルダ:").grid(
+            row=1, column=0, sticky=W, padx=(0, 10), pady=(10, 0)
+        )
+        ttk.Entry(file_frame, textvariable=self.output_dir_var, width=50).grid(
+            row=1, column=1, sticky="WE", padx=(0, 10), pady=(10, 0)
+        )
+        ttk.Button(file_frame, text="参照", command=self.browse_output_dir).grid(
+            row=1, column=2, pady=(10, 0)
+        )
+
+        # Options section
+        options_frame = ttk.LabelFrame(main_frame, text="変換オプション", padding="10")
+        options_frame.grid(row=3, column=0, columnspan=3, sticky="WE", pady=(0, 10))
+        options_frame.columnconfigure(1, weight=1)
+
+        ttk.Label(options_frame, text="テンプレート:").grid(
+            row=0, column=0, sticky=W, padx=(0, 10)
+        )
+        template_combo = ttk.Combobox(
+            options_frame,
+            textvariable=self.template_var,
+            values=["base.html.j2", "base-with-source-toggle.html.j2"],
+            state="readonly",
+        )
+        template_combo.grid(row=0, column=1, sticky="WE", padx=(0, 10))
+
+        ttk.Checkbutton(
+            options_frame,
+            text="ソース表示機能を含める",
+            variable=self.include_source_var,
+            command=self.on_source_toggle_change,
+        ).grid(row=1, column=0, columnspan=2, sticky=W, pady=(10, 0))
+
+        ttk.Checkbutton(
+            options_frame,
+            text="変換後のプレビューをスキップ",
+            variable=self.no_preview_var,
+        ).grid(row=2, column=0, columnspan=2, sticky=W, pady=(5, 0))
+
+        # Action buttons
+        button_frame = ttk.Frame(main_frame)
+        button_frame.grid(row=4, column=0, columnspan=3, pady=20)
+
+        ttk.Button(
+            button_frame,
+            text="変換実行",
+            command=self.convert_file,
+            style="Accent.TButton",
+        ).pack(side=LEFT, padx=(0, 10))
+
+        ttk.Button(
+            button_frame, text="サンプル生成", command=self.generate_sample
+        ).pack(side=LEFT, padx=(0, 10))
+
+        ttk.Button(button_frame, text="ヘルプ", command=self.show_help).pack(
+            side=LEFT, padx=(0, 10)
+        )
+
+        # デバッグモードの時のみログビューアーボタンを表示
+        if is_debug_enabled():
+            ttk.Button(button_frame, text="ログ", command=self.show_log_viewer).pack(  # type: ignore[misc]
+                side=LEFT, padx=(0, 10)
+            )
+
+        ttk.Button(button_frame, text="終了", command=self.root.quit).pack(side=LEFT)
+
+        # Progress section
+        progress_frame = ttk.LabelFrame(main_frame, text="進行状況", padding="10")
+        progress_frame.grid(row=5, column=0, columnspan=3, sticky="WE", pady=(0, 10))
+        progress_frame.columnconfigure(0, weight=1)
+
+        self.progress_bar = ttk.Progressbar(
+            progress_frame, variable=self.progress_var, maximum=100
+        )
+        self.progress_bar.grid(row=0, column=0, sticky="WE", pady=(0, 5))
+
+        self.status_label = ttk.Label(progress_frame, textvariable=self.status_var)
+        self.status_label.grid(row=1, column=0, sticky=W)
+
+        # ログビューアーの参照を保持
+        self.log_viewer: Optional["LogViewerWindow"] = None
+
+        # Log section
+        log_frame = ttk.LabelFrame(main_frame, text="ログ", padding="10")
+        log_frame.grid(row=6, column=0, columnspan=3, sticky="WENS", pady=(0, 10))
+        log_frame.columnconfigure(0, weight=1)
+        log_frame.rowconfigure(0, weight=1)
+        main_frame.rowconfigure(6, weight=1)
+
+        self.log_text = Text(log_frame, height=8, wrap=WORD, state=DISABLED)
+        log_scrollbar = ttk.Scrollbar(
+            log_frame, orient=VERTICAL, command=self.log_text.yview
+        )
+        self.log_text.configure(yscrollcommand=log_scrollbar.set)
+
+        self.log_text.grid(row=0, column=0, sticky="WENS")
+        log_scrollbar.grid(row=0, column=1, sticky="NS")
+
+    def center_window(self) -> None:
+        """Center the window on screen"""
+        self.root.update_idletasks()
+        width = self.root.winfo_width()
+        height = self.root.winfo_height()
+        pos_x = (self.root.winfo_screenwidth() // 2) - (width // 2)
+        pos_y = (self.root.winfo_screenheight() // 2) - (height // 2)
+        self.root.geometry(f"{width}x{height}+{pos_x}+{pos_y}")
+
+    @log_gui_method  # type: ignore
+    def browse_input_file(self) -> None:
+        """Browse for input file"""
+        log_gui_event("button_click", "browse_input_file")
+        filename = filedialog.askopenfilename(
+            title="変換するテキストファイルを選択",
+            filetypes=[("テキストファイル", "*.txt"), ("すべてのファイル", "*.*")],
+        )
+        if filename:
+            info(f"Input file selected: {filename}")
+            self.input_file_var.set(filename)
+        else:
+            debug("Input file selection cancelled")
+
+    def browse_output_dir(self) -> None:
+        """Browse for output directory"""
+        dirname = filedialog.askdirectory(title="出力フォルダを選択")
+        if dirname:
+            self.output_dir_var.set(dirname)
+
+    def on_source_toggle_change(self) -> None:
+        """Handle source toggle checkbox change"""
+        if self.include_source_var.get():
+            self.template_var.set("base-with-source-toggle.html.j2")
+        else:
+            self.template_var.set("base.html.j2")
+
+    def log_message(self, message: str, level: str = "info") -> None:
+        """Add message to log"""
+        self.log_text.config(state=NORMAL)
+        timestamp = __import__("datetime").datetime.now().strftime("%H:%M:%S")
+
+        if level == "error":
+            prefix = "❌"
+        elif level == "success":
+            prefix = "✅"
+        elif level == "warning":
+            prefix = "⚠️"
+        else:
+            prefix = "ℹ️"
+
+        self.log_text.insert(END, f"[{timestamp}] {prefix} {message}\n")
+        self.log_text.config(state=DISABLED)
+        self.log_text.see(END)
+        self.root.update_idletasks()
+
+    def update_progress(self, value: float, status: str = "") -> None:
+        """Update progress bar and status"""
+        self.progress_var.set(value)
+        if status:
+            self.status_var.set(status)
+        self.root.update_idletasks()
+
+    def convert_file(self) -> None:
+        """Execute file conversion in separate thread"""
+        input_file = self.input_file_var.get().strip()
+        if not input_file:
+            messagebox.showerror("エラー", "入力ファイルを選択してください。")
+            return
+
+        if not Path(input_file).exists():
+            messagebox.showerror("エラー", "指定されたファイルが見つかりません。")
+            return
+
+        # Disable UI elements during conversion
+        self.set_ui_enabled(False)
+
+        # Start conversion in separate thread
+        thread = threading.Thread(target=self._convert_file_thread)
+        thread.daemon = True
+        thread.start()
+
+    def _convert_file_thread(self) -> None:
+        """File conversion thread"""
+        try:
+            self.log_message("変換を開始します...")
+            self.update_progress(0, "変換準備中...")
+
+            input_file = self.input_file_var.get()
+            output_dir = self.output_dir_var.get()
+            template = self.template_var.get()
+            include_source = self.include_source_var.get()
+            no_preview = self.no_preview_var.get()
+
+            self.update_progress(20, "設定を読み込み中...")
+
+            # Execute conversion
+            try:
+                convert_command = ConvertCommand()
+                self.update_progress(40, "ファイルを変換中...")
+
+                # Execute conversion with GUI-friendly parameters
+                convert_command.execute(
+                    input_file=input_file,
+                    output=output_dir,
+                    no_preview=no_preview,
+                    watch=False,
+                    config=None,
+                    show_test_cases=False,
+                    template_name=template,
+                    include_source=include_source,
+                    syntax_check=True,
+                )
+
+                self.update_progress(90, "変換完了...")
+
+                # Success message
+                output_path = Path(output_dir) / f"{Path(input_file).stem}.html"
+                self.log_message(f"変換が完了しました: {output_path}", "success")
+
+                if not no_preview and output_path.exists():
+                    self.log_message("ブラウザでプレビューを開いています...")
+                    webbrowser.open(output_path.resolve().as_uri())
+
+                self.update_progress(100, "完了")
+
+                # Show success dialog
+                self.root.after(
+                    0,
+                    lambda: messagebox.showinfo(
+                        "変換完了",
+                        f"ファイルの変換が完了しました。\n\n出力先: {output_path}",
+                    ),
+                )
+
+            except Exception as e:
+                self.log_message(f"変換エラー: {str(e)}", "error")
+                self.root.after(
+                    0,
+                    lambda: messagebox.showerror(
+                        "変換エラー", f"変換中にエラーが発生しました:\n\n{str(e)}"
+                    ),
+                )
+
+        except Exception as e:
+            self.log_message(f"予期しないエラー: {str(e)}", "error")
+            self.root.after(
+                0,
+                lambda: messagebox.showerror(
+                    "エラー", f"予期しないエラーが発生しました:\n\n{str(e)}"
+                ),
+            )
+
+        finally:
+            # Re-enable UI
+            self.root.after(0, lambda: self.set_ui_enabled(True))
+            self.update_progress(0, "準備完了")
+
+    def generate_sample(self) -> None:
+        """Generate sample files in separate thread"""
+        # Disable UI elements during generation
+        self.set_ui_enabled(False)
+
+        # Start generation in separate thread
+        thread = threading.Thread(target=self._generate_sample_thread)
+        thread.daemon = True
+        thread.start()
+
+    def _generate_sample_thread(self) -> None:
+        """Sample generation thread"""
+        try:
+            self.log_message("サンプルファイルの生成を開始します...")
+            self.update_progress(0, "サンプル生成準備中...")
+
+            use_source_toggle = self.include_source_var.get()
+
+            self.update_progress(30, "サンプルファイルを作成中...")
+
+            # Execute sample generation
+            try:
+                sample_command = SampleCommand()
+            except Exception as init_error:
+                self.log_message(
+                    f"SampleCommandの初期化エラー: {str(init_error)}", "error"
+                )
+                raise init_error
+
+            output_path = sample_command.execute(
+                output_dir="kumihan_sample", use_source_toggle=use_source_toggle
+            )
+
+            self.update_progress(80, "サンプル生成完了...")
+
+            self.log_message(
+                f"サンプルファイルが生成されました: {output_path.absolute()}", "success"
+            )
+
+            # Open sample HTML
+            sample_html = output_path / "showcase.html"
+            if sample_html.exists():
+                self.log_message("ブラウザでサンプルを開いています...")
+                webbrowser.open(sample_html.resolve().as_uri())
+
+            # Open directory in Finder (macOS)
+            import platform
+            import subprocess
+
+            if platform.system() == "Darwin":  # macOS
+                self.log_message("Finderでフォルダを開いています...")
+                subprocess.run(["open", str(output_path.absolute())])
+
+            self.update_progress(100, "完了")
+
+            # Show success dialog with more detail
+            self.root.after(
+                0,
+                lambda: messagebox.showinfo(
+                    "サンプル生成完了",
+                    f"サンプルファイルの生成が完了しました。\n\n"
+                    f"出力先: {output_path.absolute()}\n\n"
+                    f"生成されたファイル:\n"
+                    f"• showcase.html (メインHTML)\n"
+                    f"• showcase.txt (ソーステキスト)\n"
+                    f"• images/ (サンプル画像)\n\n"
+                    f"Finderでフォルダを開きました。",
+                ),
+            )
+
+        except Exception as e:
+            import traceback
+
+            error_details = traceback.format_exc()
+            self.log_message(f"サンプル生成エラー: {str(e)}", "error")
+            self.log_message(f"詳細: {error_details}", "error")
+            self.root.after(
+                0,
+                lambda: messagebox.showerror(
+                    "サンプル生成エラー",
+                    f"サンプル生成中にエラーが発生しました:\n\n{str(e)}\n\n詳細はログを確認してください。",
+                ),
+            )
+
+        finally:
+            # Re-enable UI
+            self.root.after(0, lambda: self.set_ui_enabled(True))
+            self.update_progress(0, "準備完了")
+
+    def set_ui_enabled(self, enabled: bool) -> None:
+        """Enable/disable UI elements"""
+        state = NORMAL if enabled else DISABLED
+
+        # Find all widgets and update their state
+        def update_widget_state(widget) -> None:  # type: ignore
+            try:
+                if isinstance(
+                    widget, (ttk.Button, ttk.Entry, ttk.Combobox, ttk.Checkbutton)
+                ):
+                    widget.configure(state=state)
+            except:
+                pass
+
+            for child in widget.winfo_children():
+                update_widget_state(child)
+
+        update_widget_state(self.root)
+
+    def show_help(self) -> None:
+        """Show help dialog"""
+        help_text = """Kumihan-Formatter GUI ヘルプ
+
+【基本的な使い方】
+1. 「参照」ボタンから変換したいテキストファイルを選択
+2. 出力フォルダを指定（デフォルト: ./dist）
+3. 必要に応じてオプションを設定
+4. 「変換実行」ボタンをクリック
+
+【オプション説明】
+• テンプレート: 出力HTMLのテンプレートを選択
+• ソース表示機能: 原文と変換結果を切り替え表示する機能
+• プレビューをスキップ: 変換後にブラウザを自動で開かない
+
+【サンプル生成】
+「サンプル生成」ボタンで機能紹介用のサンプルファイルを生成できます。
+
+【サポート】
+詳細な使い方やトラブルシューティングは、
+プロジェクトのドキュメントを参照してください。
+
+GitHub: https://github.com/mo9mo9-uwu-mo9mo9/Kumihan-Formatter
+"""
+
+        help_window = Toplevel(self.root)
+        help_window.title("ヘルプ")
+        help_window.geometry("600x500")
+        help_window.transient(self.root)
+        help_window.grab_set()
+
+        # Center help window
+        help_window.update_idletasks()
+        x = (help_window.winfo_screenwidth() // 2) - (600 // 2)
+        y = (help_window.winfo_screenheight() // 2) - (500 // 2)
+        help_window.geometry(f"600x500+{x}+{y}")
+
+        # Help content
+        text_frame = Frame(help_window)
+        text_frame.pack(fill=BOTH, expand=True, padx=20, pady=20)
+
+        help_text_widget = Text(text_frame, wrap=WORD, padx=10, pady=10)
+        help_scrollbar = ttk.Scrollbar(
+            text_frame, orient=VERTICAL, command=help_text_widget.yview
+        )
+        help_text_widget.configure(yscrollcommand=help_scrollbar.set)
+
+        help_text_widget.pack(side=LEFT, fill=BOTH, expand=True)
+        help_scrollbar.pack(side=RIGHT, fill=Y)
+
+        help_text_widget.insert("1.0", help_text)
+        help_text_widget.config(state=DISABLED)
+
+        # Close button
+        ttk.Button(help_window, text="閉じる", command=help_window.destroy).pack(
+            pady=10
+        )
+
+    @log_gui_method  # type: ignore
+    def show_log_viewer(self) -> None:
+        """Show debug log viewer window"""
+        log_gui_event("button_click", "show_log_viewer")
+        try:
+            if self.log_viewer and self.log_viewer.is_open():
+                # 既に開いている場合は前面に表示
+                if self.log_viewer.window:
+                    self.log_viewer.window.lift()
+                    self.log_viewer.window.focus_force()
+            else:
+                # 新しいログビューアーを開く
+                from .core.log_viewer import LogViewerWindow
+
+                self.log_viewer = LogViewerWindow(self.root)
+                self.log_viewer.show()
+                info("Log viewer window opened")
+        except Exception as e:
+            error("Failed to open log viewer", e)
+            messagebox.showerror(
+                "エラー", f"ログビューアーの表示に失敗しました:\n\n{str(e)}"
+            )
+
+    def run(self) -> None:
+        """Start the GUI application"""
+        self.log_message("Kumihan-Formatter GUI が起動しました")
+        self.log_message(
+            "使い方がわからない場合は「ヘルプ」ボタンをクリックしてください"
+        )
+        self.root.mainloop()
+
+
+def main() -> None:
+    """Main entry point for GUI launcher"""
+    try:
+        app = KumihanGUI()
+        app.run()
+    except Exception as e:
+        # Fallback error handling for GUI startup issues
+        import tkinter.messagebox as mb
+
+        mb.showerror(
+            "起動エラー",
+            f"GUIの起動中にエラーが発生しました:\n\n{str(e)}\n\nコマンドライン版の使用をお試しください。",
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/kumihan_formatter/gui_models.py
+++ b/kumihan_formatter/gui_models.py
@@ -1,0 +1,297 @@
+"""GUI Models for Kumihan-Formatter
+
+Model層: データ・設定管理とビジネスロジック
+MVCパターンでのModel部分を担当し、UIから独立したデータ処理を提供
+"""
+
+from pathlib import Path
+from tkinter import BooleanVar, DoubleVar, StringVar
+from typing import Any, Dict, Optional
+
+
+class GuiConfig:
+    """GUI設定管理クラス
+
+    ユーザーの設定項目（ファイルパス、オプション等）を管理
+    """
+
+    def __init__(self) -> None:
+        """設定項目の初期化"""
+        # ファイル関連設定
+        self.input_file_var = StringVar()
+        self.output_dir_var = StringVar(value="./dist")
+
+        # テンプレート設定
+        self.template_var = StringVar(value="base.html.j2")
+        self.available_templates = ["base.html.j2", "base-with-source-toggle.html.j2"]
+
+        # オプション設定
+        self.include_source_var = BooleanVar(value=False)
+        self.no_preview_var = BooleanVar(value=False)
+
+    def get_input_file(self) -> str:
+        """入力ファイルパスを取得"""
+        return self.input_file_var.get().strip()
+
+    def set_input_file(self, path: str) -> None:
+        """入力ファイルパスを設定"""
+        self.input_file_var.set(path)
+
+    def get_output_dir(self) -> str:
+        """出力ディレクトリを取得"""
+        return self.output_dir_var.get().strip()
+
+    def set_output_dir(self, path: str) -> None:
+        """出力ディレクトリを設定"""
+        self.output_dir_var.set(path)
+
+    def get_template(self) -> str:
+        """選択されたテンプレートを取得"""
+        return self.template_var.get()
+
+    def set_template(self, template: str) -> None:
+        """テンプレートを設定"""
+        if template in self.available_templates:
+            self.template_var.set(template)
+
+    def get_include_source(self) -> bool:
+        """ソース表示オプションを取得"""
+        return self.include_source_var.get()
+
+    def set_include_source(self, value: bool) -> None:
+        """ソース表示オプションを設定"""
+        self.include_source_var.set(value)
+        # ソース表示が有効な場合、自動でテンプレートを切り替え
+        if value:
+            self.set_template("base-with-source-toggle.html.j2")
+        else:
+            self.set_template("base.html.j2")
+
+    def get_no_preview(self) -> bool:
+        """プレビュー無効化オプションを取得"""
+        return self.no_preview_var.get()
+
+    def set_no_preview(self, value: bool) -> None:
+        """プレビュー無効化オプションを設定"""
+        self.no_preview_var.set(value)
+
+    def validate_input_file(self) -> bool:
+        """入力ファイルの妥当性チェック"""
+        input_file = self.get_input_file()
+        if not input_file:
+            return False
+        return Path(input_file).exists()
+
+    def get_conversion_params(self) -> Dict[str, Any]:
+        """変換実行用のパラメータを取得"""
+        return {
+            "input_file": self.get_input_file(),
+            "output": self.get_output_dir(),
+            "template_name": self.get_template(),
+            "include_source": self.get_include_source(),
+            "no_preview": self.get_no_preview(),
+            "watch": False,
+            "config": None,
+            "show_test_cases": False,
+            "syntax_check": True,
+        }
+
+
+class ConversionState:
+    """変換処理の状態管理クラス
+
+    進捗状況、ステータスメッセージ、処理状態を管理
+    """
+
+    def __init__(self) -> None:
+        """状態管理変数の初期化"""
+        self.progress_var = DoubleVar()
+        self.status_var = StringVar(value="準備完了")
+        self.is_processing = False
+
+    def get_progress(self) -> float:
+        """現在の進捗値を取得"""
+        return self.progress_var.get()
+
+    def set_progress(self, value: float) -> None:
+        """進捗値を設定（0-100）"""
+        self.progress_var.set(max(0, min(100, value)))
+
+    def get_status(self) -> str:
+        """現在のステータスメッセージを取得"""
+        return self.status_var.get()
+
+    def set_status(self, message: str) -> None:
+        """ステータスメッセージを設定"""
+        self.status_var.set(message)
+
+    def update_progress(self, value: float, status: str = "") -> None:
+        """進捗とステータスを同時更新"""
+        self.set_progress(value)
+        if status:
+            self.set_status(status)
+
+    def start_processing(self) -> None:
+        """処理開始"""
+        self.is_processing = True
+        self.set_progress(0)
+        self.set_status("処理中...")
+
+    def finish_processing(self, success: bool = True) -> None:
+        """処理完了"""
+        self.is_processing = False
+        if success:
+            self.set_progress(100)
+            self.set_status("完了")
+        else:
+            self.set_progress(0)
+            self.set_status("エラー")
+
+    def reset(self) -> None:
+        """状態をリセット"""
+        self.is_processing = False
+        self.set_progress(0)
+        self.set_status("準備完了")
+
+
+class FileManager:
+    """ファイル操作管理クラス
+
+    ファイル選択、パス管理、出力パス生成等のファイル関連処理
+    """
+
+    @staticmethod
+    def get_output_html_path(input_file: str, output_dir: str) -> Path:
+        """入力ファイルから出力HTMLファイルのパスを生成"""
+        if not input_file:
+            raise ValueError("入力ファイルが指定されていません")
+
+        input_path = Path(input_file)
+        output_path = Path(output_dir) / f"{input_path.stem}.html"
+        return output_path
+
+    @staticmethod
+    def validate_file_exists(file_path: str) -> bool:
+        """ファイルの存在確認"""
+        if not file_path:
+            return False
+        return Path(file_path).exists()
+
+    @staticmethod
+    def validate_directory_writable(dir_path: str) -> bool:
+        """ディレクトリの書き込み可能性確認"""
+        try:
+            directory = Path(dir_path)
+            directory.mkdir(parents=True, exist_ok=True)
+            return directory.is_dir()
+        except (OSError, PermissionError):
+            return False
+
+    @staticmethod
+    def get_file_size_mb(file_path: str) -> float:
+        """ファイルサイズをMB単位で取得"""
+        try:
+            return Path(file_path).stat().st_size / (1024 * 1024)
+        except (OSError, FileNotFoundError):
+            return 0.0
+
+    @staticmethod
+    def get_sample_output_path(output_dir: str = "kumihan_sample") -> Path:
+        """サンプル生成用の出力パスを取得"""
+        return Path(output_dir)
+
+
+class LogManager:
+    """ログ管理クラス
+
+    GUIログの管理、メッセージレベル、タイムスタンプ処理
+    """
+
+    LOG_LEVELS = {"info": "ℹ️", "success": "✅", "warning": "⚠️", "error": "❌"}
+
+    def __init__(self) -> None:
+        """ログ管理の初期化"""
+        self.messages: list[Dict[str, str]] = []
+
+    @staticmethod
+    def format_log_message(message: str, level: str = "info") -> str:
+        """ログメッセージのフォーマット"""
+        import datetime
+
+        timestamp = datetime.datetime.now().strftime("%H:%M:%S")
+        prefix = LogManager.LOG_LEVELS.get(level, "ℹ️")
+        return f"[{timestamp}] {prefix} {message}"
+
+    def add_message(self, message: str, level: str = "info") -> str:
+        """ログメッセージを追加してフォーマットされたメッセージを返す"""
+        formatted = self.format_log_message(message, level)
+        self.messages.append(
+            {
+                "message": message,
+                "level": level,
+                "formatted": formatted,
+                "timestamp": self._get_timestamp(),
+            }
+        )
+        return formatted
+
+    def _get_timestamp(self) -> str:
+        """現在のタイムスタンプを取得"""
+        import datetime
+
+        return datetime.datetime.now().isoformat()
+
+    def get_recent_messages(self, count: int = 50) -> list[str]:
+        """最新のメッセージを取得"""
+        return [msg["formatted"] for msg in self.messages[-count:]]
+
+    def clear_messages(self) -> None:
+        """ログメッセージをクリア"""
+        self.messages.clear()
+
+
+class AppState:
+    """アプリケーション全体の状態管理クラス
+
+    GUI、変換、ファイル、ログの各管理クラスを統合
+    """
+
+    def __init__(self) -> None:
+        """アプリケーション状態の初期化"""
+        self.config = GuiConfig()
+        self.conversion_state = ConversionState()
+        self.file_manager = FileManager()
+        self.log_manager = LogManager()
+
+        # デバッグモード
+        self.debug_mode = self._check_debug_mode()
+
+    def _check_debug_mode(self) -> bool:
+        """デバッグモードの確認"""
+        import os
+
+        return os.environ.get("KUMIHAN_GUI_DEBUG", "false").lower() == "true"
+
+    def is_ready_for_conversion(self) -> tuple[bool, str]:
+        """変換実行可能かチェック"""
+        if self.conversion_state.is_processing:
+            return False, "処理中です"
+
+        if not self.config.validate_input_file():
+            return False, "入力ファイルを選択してください"
+
+        if not self.file_manager.validate_directory_writable(
+            self.config.get_output_dir()
+        ):
+            return False, "出力ディレクトリが無効です"
+
+        return True, "変換可能"
+
+    def get_output_file_path(self) -> Optional[Path]:
+        """出力ファイルパスを取得"""
+        try:
+            return self.file_manager.get_output_html_path(
+                self.config.get_input_file(), self.config.get_output_dir()
+            )
+        except ValueError:
+            return None

--- a/kumihan_formatter/gui_views.py
+++ b/kumihan_formatter/gui_views.py
@@ -1,0 +1,539 @@
+"""GUI Views for Kumihan-Formatter
+
+View層: UIコンポーネント管理とレイアウト
+MVCパターンでのView部分を担当し、ユーザーインターフェースの構築・更新を提供
+"""
+
+from tkinter import *
+from tkinter import ttk
+from typing import Any, Callable, Optional
+
+from .gui_models import AppState
+
+
+class MainWindow:
+    """メインウィンドウクラス
+
+    アプリケーションのメインウィンドウとグローバルレイアウトを管理
+    """
+
+    def __init__(self, app_state: AppState) -> None:
+        """メインウィンドウの初期化"""
+        self.app_state = app_state
+        self.root = Tk()
+        self._setup_window()
+        self._setup_style()
+
+    def _setup_window(self) -> None:
+        """ウィンドウの基本設定"""
+        self.root.title("Kumihan-Formatter v1.0 - 美しい組版を、誰でも簡単に")
+        self.root.geometry("800x600")
+        self.root.resizable(True, True)
+
+    def _setup_style(self) -> None:
+        """スタイルの設定"""
+        self.style = ttk.Style()
+        self.style.theme_use("clam")
+
+    def center_window(self) -> None:
+        """ウィンドウを画面中央に配置"""
+        self.root.update_idletasks()
+        width = self.root.winfo_width()
+        height = self.root.winfo_height()
+        pos_x = (self.root.winfo_screenwidth() // 2) - (width // 2)
+        pos_y = (self.root.winfo_screenheight() // 2) - (height // 2)
+        self.root.geometry(f"{width}x{height}+{pos_x}+{pos_y}")
+
+    def get_root(self) -> Tk:
+        """Tkルートウィンドウを取得"""
+        return self.root
+
+
+class HeaderFrame:
+    """ヘッダーフレームクラス
+
+    タイトルとサブタイトルを表示するヘッダー部分
+    """
+
+    def __init__(self, parent: Widget) -> None:
+        """ヘッダーフレームの初期化"""
+        self.parent = parent
+        self.frame = ttk.Frame(parent)
+        self._setup_header()
+
+    def _setup_header(self) -> None:
+        """ヘッダーの構築"""
+        # タイトル
+        self.title_label = ttk.Label(
+            self.frame, text="Kumihan-Formatter", font=("Arial", 16, "bold")
+        )
+        self.title_label.grid(row=0, column=0, columnspan=3, pady=(0, 20))
+
+        # サブタイトル
+        self.subtitle_label = ttk.Label(
+            self.frame,
+            text="美しい組版を、誰でも簡単に。テキストファイルをワンクリックでHTMLに変換",
+            font=("Arial", 10),
+        )
+        self.subtitle_label.grid(row=1, column=0, columnspan=3, pady=(0, 20))
+
+    def pack(self, **kwargs: Any) -> None:
+        """フレームをパック"""
+        self.frame.pack(**kwargs)
+
+    def grid(self, **kwargs: Any) -> None:
+        """フレームをグリッド配置"""
+        self.frame.grid(**kwargs)
+
+
+class FileSelectionFrame:
+    """ファイル選択フレームクラス
+
+    入力ファイルと出力ディレクトリの選択UI
+    """
+
+    def __init__(self, parent: Widget, app_state: AppState) -> None:
+        """ファイル選択フレームの初期化"""
+        self.parent = parent
+        self.app_state = app_state
+        self.frame = ttk.LabelFrame(parent, text="ファイル選択", padding="10")
+        self._setup_file_selection()
+
+    def _setup_file_selection(self) -> None:
+        """ファイル選択UIの構築"""
+        self.frame.columnconfigure(1, weight=1)
+
+        # 入力ファイル選択
+        ttk.Label(self.frame, text="入力ファイル:").grid(
+            row=0, column=0, sticky=W, padx=(0, 10)
+        )
+        self.input_entry = ttk.Entry(
+            self.frame, textvariable=self.app_state.config.input_file_var, width=50
+        )
+        self.input_entry.grid(row=0, column=1, sticky="WE", padx=(0, 10))
+
+        self.input_browse_btn = ttk.Button(self.frame, text="参照")
+        self.input_browse_btn.grid(row=0, column=2)
+
+        # 出力ディレクトリ選択
+        ttk.Label(self.frame, text="出力フォルダ:").grid(
+            row=1, column=0, sticky=W, padx=(0, 10), pady=(10, 0)
+        )
+        self.output_entry = ttk.Entry(
+            self.frame, textvariable=self.app_state.config.output_dir_var, width=50
+        )
+        self.output_entry.grid(row=1, column=1, sticky="WE", padx=(0, 10), pady=(10, 0))
+
+        self.output_browse_btn = ttk.Button(self.frame, text="参照")
+        self.output_browse_btn.grid(row=1, column=2, pady=(10, 0))
+
+    def set_input_browse_command(self, command: Callable[[], None]) -> None:
+        """入力ファイル参照ボタンのコマンドを設定"""
+        self.input_browse_btn.configure(command=command)
+
+    def set_output_browse_command(self, command: Callable[[], None]) -> None:
+        """出力ディレクトリ参照ボタンのコマンドを設定"""
+        self.output_browse_btn.configure(command=command)
+
+    def pack(self, **kwargs: Any) -> None:
+        """フレームをパック"""
+        self.frame.pack(**kwargs)
+
+    def grid(self, **kwargs: Any) -> None:
+        """フレームをグリッド配置"""
+        self.frame.grid(**kwargs)
+
+
+class OptionsFrame:
+    """オプション設定フレームクラス
+
+    変換オプション（テンプレート、ソース表示等）の設定UI
+    """
+
+    def __init__(self, parent: Widget, app_state: AppState) -> None:
+        """オプションフレームの初期化"""
+        self.parent = parent
+        self.app_state = app_state
+        self.frame = ttk.LabelFrame(parent, text="変換オプション", padding="10")
+        self._setup_options()
+
+    def _setup_options(self) -> None:
+        """オプション設定UIの構築"""
+        self.frame.columnconfigure(1, weight=1)
+
+        # テンプレート選択
+        ttk.Label(self.frame, text="テンプレート:").grid(
+            row=0, column=0, sticky=W, padx=(0, 10)
+        )
+        self.template_combo = ttk.Combobox(
+            self.frame,
+            textvariable=self.app_state.config.template_var,
+            values=self.app_state.config.available_templates,
+            state="readonly",
+        )
+        self.template_combo.grid(row=0, column=1, sticky="WE", padx=(0, 10))
+
+        # ソース表示オプション
+        self.source_check = ttk.Checkbutton(
+            self.frame,
+            text="ソース表示機能を含める",
+            variable=self.app_state.config.include_source_var,
+        )
+        self.source_check.grid(row=1, column=0, columnspan=2, sticky=W, pady=(10, 0))
+
+        # プレビュー無効化オプション
+        self.preview_check = ttk.Checkbutton(
+            self.frame,
+            text="変換後のプレビューをスキップ",
+            variable=self.app_state.config.no_preview_var,
+        )
+        self.preview_check.grid(row=2, column=0, columnspan=2, sticky=W, pady=(5, 0))
+
+    def set_source_toggle_command(self, command: Callable[[], None]) -> None:
+        """ソース表示チェックボックスのコマンドを設定"""
+        self.source_check.configure(command=command)
+
+    def pack(self, **kwargs: Any) -> None:
+        """フレームをパック"""
+        self.frame.pack(**kwargs)
+
+    def grid(self, **kwargs: Any) -> None:
+        """フレームをグリッド配置"""
+        self.frame.grid(**kwargs)
+
+
+class ActionButtonFrame:
+    """アクションボタンフレームクラス
+
+    変換実行、サンプル生成、ヘルプ等のアクションボタン
+    """
+
+    def __init__(self, parent: Widget, app_state: AppState) -> None:
+        """アクションボタンフレームの初期化"""
+        self.parent = parent
+        self.app_state = app_state
+        self.frame = ttk.Frame(parent)
+        self._setup_buttons()
+
+    def _setup_buttons(self) -> None:
+        """ボタンUIの構築"""
+        # 変換実行ボタン
+        self.convert_btn = ttk.Button(
+            self.frame,
+            text="変換実行",
+            style="Accent.TButton",
+        )
+        self.convert_btn.pack(side=LEFT, padx=(0, 10))
+
+        # サンプル生成ボタン
+        self.sample_btn = ttk.Button(self.frame, text="サンプル生成")
+        self.sample_btn.pack(side=LEFT, padx=(0, 10))
+
+        # ヘルプボタン
+        self.help_btn = ttk.Button(self.frame, text="ヘルプ")
+        self.help_btn.pack(side=LEFT, padx=(0, 10))
+
+        # デバッグモード時のログボタン
+        if self.app_state.debug_mode:
+            self.log_btn = ttk.Button(self.frame, text="ログ")
+            self.log_btn.pack(side=LEFT, padx=(0, 10))
+
+        # 終了ボタン
+        self.exit_btn = ttk.Button(self.frame, text="終了")
+        self.exit_btn.pack(side=LEFT)
+
+    def set_convert_command(self, command: Callable[[], None]) -> None:
+        """変換実行ボタンのコマンドを設定"""
+        self.convert_btn.configure(command=command)
+
+    def set_sample_command(self, command: Callable[[], None]) -> None:
+        """サンプル生成ボタンのコマンドを設定"""
+        self.sample_btn.configure(command=command)
+
+    def set_help_command(self, command: Callable[[], None]) -> None:
+        """ヘルプボタンのコマンドを設定"""
+        self.help_btn.configure(command=command)
+
+    def set_log_command(self, command: Callable[[], None]) -> None:
+        """ログボタンのコマンドを設定（デバッグモード時のみ）"""
+        if hasattr(self, "log_btn"):
+            self.log_btn.configure(command=command)
+
+    def set_exit_command(self, command: Callable[[], None]) -> None:
+        """終了ボタンのコマンドを設定"""
+        self.exit_btn.configure(command=command)
+
+    def pack(self, **kwargs: Any) -> None:
+        """フレームをパック"""
+        self.frame.pack(**kwargs)
+
+    def grid(self, **kwargs: Any) -> None:
+        """フレームをグリッド配置"""
+        self.frame.grid(**kwargs)
+
+
+class ProgressFrame:
+    """進捗表示フレームクラス
+
+    進捗バーとステータス表示
+    """
+
+    def __init__(self, parent: Widget, app_state: AppState) -> None:
+        """進捗フレームの初期化"""
+        self.parent = parent
+        self.app_state = app_state
+        self.frame = ttk.LabelFrame(parent, text="進行状況", padding="10")
+        self._setup_progress()
+
+    def _setup_progress(self) -> None:
+        """進捗表示UIの構築"""
+        self.frame.columnconfigure(0, weight=1)
+
+        # 進捗バー
+        self.progress_bar = ttk.Progressbar(
+            self.frame,
+            variable=self.app_state.conversion_state.progress_var,
+            maximum=100,
+        )
+        self.progress_bar.grid(row=0, column=0, sticky="WE", pady=(0, 5))
+
+        # ステータスラベル
+        self.status_label = ttk.Label(
+            self.frame, textvariable=self.app_state.conversion_state.status_var
+        )
+        self.status_label.grid(row=1, column=0, sticky=W)
+
+    def pack(self, **kwargs: Any) -> None:
+        """フレームをパック"""
+        self.frame.pack(**kwargs)
+
+    def grid(self, **kwargs: Any) -> None:
+        """フレームをグリッド配置"""
+        self.frame.grid(**kwargs)
+
+
+class LogFrame:
+    """ログ表示フレームクラス
+
+    実行ログの表示とスクロール
+    """
+
+    def __init__(self, parent: Widget, app_state: AppState) -> None:
+        """ログフレームの初期化"""
+        self.parent = parent
+        self.app_state = app_state
+        self.frame = ttk.LabelFrame(parent, text="ログ", padding="10")
+        self._setup_log()
+
+    def _setup_log(self) -> None:
+        """ログ表示UIの構築"""
+        self.frame.columnconfigure(0, weight=1)
+        self.frame.rowconfigure(0, weight=1)
+
+        # ログテキストエリア
+        self.log_text = Text(self.frame, height=8, wrap=WORD, state=DISABLED)
+
+        # スクロールバー
+        self.log_scrollbar = ttk.Scrollbar(
+            self.frame, orient=VERTICAL, command=self.log_text.yview
+        )
+        self.log_text.configure(yscrollcommand=self.log_scrollbar.set)
+
+        # 配置
+        self.log_text.grid(row=0, column=0, sticky="WENS")
+        self.log_scrollbar.grid(row=0, column=1, sticky="NS")
+
+    def add_message(self, message: str, level: str = "info") -> None:
+        """ログメッセージを追加"""
+        formatted_message = self.app_state.log_manager.add_message(message, level)
+
+        self.log_text.config(state=NORMAL)
+        self.log_text.insert(END, formatted_message + "\n")
+        self.log_text.config(state=DISABLED)
+        self.log_text.see(END)
+
+    def clear_log(self) -> None:
+        """ログをクリア"""
+        self.log_text.config(state=NORMAL)
+        self.log_text.delete(1.0, END)
+        self.log_text.config(state=DISABLED)
+        self.app_state.log_manager.clear_messages()
+
+    def pack(self, **kwargs: Any) -> None:
+        """フレームをパック"""
+        self.frame.pack(**kwargs)
+
+    def grid(self, **kwargs: Any) -> None:
+        """フレームをグリッド配置"""
+        self.frame.grid(**kwargs)
+
+
+class HelpDialog:
+    """ヘルプダイアログクラス
+
+    ヘルプ情報を表示するモーダルダイアログ
+    """
+
+    def __init__(self, parent: Tk) -> None:
+        """ヘルプダイアログの初期化"""
+        self.parent = parent
+        self.window: Optional[Toplevel] = None
+
+    def show(self) -> None:
+        """ヘルプダイアログを表示"""
+        if self.window:
+            self.window.destroy()
+
+        self.window = Toplevel(self.parent)
+        self.window.title("ヘルプ")
+        self.window.geometry("600x500")
+        self.window.transient(self.parent)
+        self.window.grab_set()
+
+        self._center_window()
+        self._setup_content()
+
+    def _center_window(self) -> None:
+        """ダイアログを画面中央に配置"""
+        if not self.window:
+            return
+
+        self.window.update_idletasks()
+        x = (self.window.winfo_screenwidth() // 2) - (600 // 2)
+        y = (self.window.winfo_screenheight() // 2) - (500 // 2)
+        self.window.geometry(f"600x500+{x}+{y}")
+
+    def _setup_content(self) -> None:
+        """ヘルプコンテンツの設定"""
+        if not self.window:
+            return
+
+        help_text = """Kumihan-Formatter GUI ヘルプ
+
+【基本的な使い方】
+1. 「参照」ボタンから変換したいテキストファイルを選択
+2. 出力フォルダを指定（デフォルト: ./dist）
+3. 必要に応じてオプションを設定
+4. 「変換実行」ボタンをクリック
+
+【オプション説明】
+• テンプレート: 出力HTMLのテンプレートを選択
+• ソース表示機能: 原文と変換結果を切り替え表示する機能
+• プレビューをスキップ: 変換後にブラウザを自動で開かない
+
+【サンプル生成】
+「サンプル生成」ボタンで機能紹介用のサンプルファイルを生成できます。
+
+【サポート】
+詳細な使い方やトラブルシューティングは、
+プロジェクトのドキュメントを参照してください。
+
+GitHub: https://github.com/mo9mo9-uwu-mo9mo9/Kumihan-Formatter
+"""
+
+        # コンテンツフレーム
+        text_frame = Frame(self.window)
+        text_frame.pack(fill=BOTH, expand=True, padx=20, pady=20)
+
+        # ヘルプテキスト
+        help_text_widget = Text(text_frame, wrap=WORD, padx=10, pady=10)
+        help_scrollbar = ttk.Scrollbar(
+            text_frame, orient=VERTICAL, command=help_text_widget.yview
+        )
+        help_text_widget.configure(yscrollcommand=help_scrollbar.set)
+
+        help_text_widget.pack(side=LEFT, fill=BOTH, expand=True)
+        help_scrollbar.pack(side=RIGHT, fill=Y)
+
+        help_text_widget.insert("1.0", help_text)
+        help_text_widget.config(state=DISABLED)
+
+        # 閉じるボタン
+        ttk.Button(self.window, text="閉じる", command=self.window.destroy).pack(
+            pady=10
+        )
+
+
+class MainView:
+    """メインビュークラス
+
+    すべてのUIコンポーネントを統合して管理する中央ビュー
+    """
+
+    def __init__(self, app_state: AppState) -> None:
+        """メインビューの初期化"""
+        self.app_state = app_state
+
+        # メインウィンドウ作成
+        self.main_window = MainWindow(app_state)
+        self.root = self.main_window.get_root()
+
+        # メインフレーム
+        self.main_frame = ttk.Frame(self.root, padding="10")
+        self.main_frame.grid(row=0, column=0, sticky="WENS")
+
+        # グリッド設定
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(0, weight=1)
+        self.main_frame.columnconfigure(1, weight=1)
+        self.main_frame.rowconfigure(6, weight=1)  # ログフレームを伸縮可能に
+
+        # UI コンポーネント作成
+        self._create_components()
+        self._layout_components()
+
+        # ウィンドウ中央配置
+        self.main_window.center_window()
+
+    def _create_components(self) -> None:
+        """UIコンポーネントの作成"""
+        self.header_frame = HeaderFrame(self.main_frame)
+        self.file_selection_frame = FileSelectionFrame(self.main_frame, self.app_state)
+        self.options_frame = OptionsFrame(self.main_frame, self.app_state)
+        self.action_button_frame = ActionButtonFrame(self.main_frame, self.app_state)
+        self.progress_frame = ProgressFrame(self.main_frame, self.app_state)
+        self.log_frame = LogFrame(self.main_frame, self.app_state)
+        self.help_dialog = HelpDialog(self.root)
+
+    def _layout_components(self) -> None:
+        """UIコンポーネントのレイアウト"""
+        self.header_frame.grid(row=0, column=0, columnspan=3, pady=(0, 20))
+        self.file_selection_frame.grid(
+            row=1, column=0, columnspan=3, sticky="WE", pady=(0, 10)
+        )
+        self.options_frame.grid(
+            row=2, column=0, columnspan=3, sticky="WE", pady=(0, 10)
+        )
+        self.action_button_frame.grid(row=3, column=0, columnspan=3, pady=20)
+        self.progress_frame.grid(
+            row=4, column=0, columnspan=3, sticky="WE", pady=(0, 10)
+        )
+        self.log_frame.grid(row=5, column=0, columnspan=3, sticky="WENS", pady=(0, 10))
+
+    def set_ui_enabled(self, enabled: bool) -> None:
+        """UI要素の有効/無効を一括設定"""
+        state = NORMAL if enabled else DISABLED
+
+        def update_widget_state(widget: Widget) -> None:
+            try:
+                if isinstance(
+                    widget, (ttk.Button, ttk.Entry, ttk.Combobox, ttk.Checkbutton)
+                ):
+                    widget.configure(state=state)
+            except:
+                pass
+
+            for child in widget.winfo_children():
+                update_widget_state(child)
+
+        # rootはTkクラスなので、直接のWidget子要素を更新
+        for child in self.root.winfo_children():
+            update_widget_state(child)
+
+    def update_display(self) -> None:
+        """画面表示を更新"""
+        self.root.update_idletasks()
+
+    def start_mainloop(self) -> None:
+        """メインループを開始"""
+        self.root.mainloop()


### PR DESCRIPTION
## Summary
Issue #476 Phase 2として、GUIコンポーネントを690行の単一ファイルから4つのMVCパターンファイルに分割リファクタリング

### 主な変更内容
- **gui_launcher.py** (690行) → **4ファイル**に分割:
  - **gui_models.py** (299行): Model層 - データ・設定管理
  - **gui_views.py** (549行): View層 - UIコンポーネント  
  - **gui_controller.py** (382行): Controller層 - イベント制御
  - **gui_launcher.py** (101行): エントリーポイント

### 分割効果
- ✅ **単一責任原則**の適用
- ✅ **テスト容易性・保守性**の向上
- ✅ **コンポーネント再利用性**の向上
- ✅ **MVCアーキテクチャ**による関心の分離

### 技術的改善
- Model: データ管理とビジネスロジックの分離
- View: UI構築とレイアウト管理の独立
- Controller: イベント処理とModel-View橋渡し
- 依存関係の明確化とインターフェース設計

## Test plan
- [x] GUI分割後のインポートテスト成功
- [x] pre-commitフック全項目パス
- [x] mypy strict mode型チェック成功

🤖 Generated with [Claude Code](https://claude.ai/code)