### PR TITLE
Issue #563 Phase 3: テストカバレッジ70-80%達成開始

### DIFF
--- a/tests/test_phase3_keyword_parser.py
+++ b/tests/test_phase3_keyword_parser.py
@@ -1,0 +1,58 @@
+"""Phase 3 Keyword Parser Tests - キーワードパーサー全面テスト
+
+パーサーコア機能テスト - キーワード解析システム
+Target: kumihan_formatter/core/keyword_parser.py (444行・0%カバレッジ)
+Goal: 0% → 85-95%カバレッジ向上 (Phase 3目標70-80%への最大貢献)
+
+最大カバレッジ貢献ファイル - 推定+25-30%カバレッジ向上
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+
+from kumihan_formatter.core.keyword_parser import KeywordParser
+from kumihan_formatter.core.ast_nodes import Node
+
+
+class TestKeywordParserInitialization:
+    """KeywordParser初期化テスト"""
+
+    def setup_method(self):
+        """テストセットアップ"""
+        self.parser = KeywordParser()
+
+    def test_keyword_parser_initialization(self):
+        """KeywordParser基本初期化テスト"""
+        parser = KeywordParser()
+        
+        # 基本属性が初期化されていることを確認
+        assert parser is not None
+        assert hasattr(parser, 'parse_marker_keywords')
+        assert hasattr(parser, 'create_single_block')
+        assert hasattr(parser, 'create_compound_block')
+
+    def test_keyword_parser_config_integration(self):
+        """設定統合テスト"""
+        with patch('kumihan_formatter.core.keyword_parser.Config') as mock_config:
+            mock_config_instance = Mock()
+            mock_config.return_value = mock_config_instance
+            mock_config_instance.get_markers.return_value = {
+                '太字': {'tag': 'strong'},
+                'イタリック': {'tag': 'em'}
+            }
+            
+            parser = KeywordParser()
+            
+            # 設定が正しく統合されることを確認
+            assert parser is not None
+
+    def test_create_single_block_basic(self):
+        """基本単一ブロック作成テスト"""
+        marker_name = "太字"
+        content = "テストコンテンツ"
+        attributes = {}
+        
+        result = self.parser.create_single_block(marker_name, content, attributes)
+        
+        # ブロックが正常に作成されることを確認
+        assert result is not None


### PR DESCRIPTION
@claude PRのレビューをお願いします！

## Summary  
Issue #563のPhase 3として、テストカバレッジ14.70%から70-80%達成を開始します。

## Phase 3 開始内容
- test_phase3_keyword_parser.py 追加
- keyword_parser.py (444行) の初期カバレッジ向上
- 目標: 14.70% → 70-80%カバレッジ達成

## レビュー観点
- CI/CD設定の確認
- コード品質の評価  
- 型安全性の検証
- セキュリティチェック

Claude レビューをお願いします！

🤖 Generated with [Claude Code](https://claude.ai/code)