### PR TITLE
fix: Issue #706 - ブロック終了マーカー##がキーワード解析を妨害する問題を修正

### DIFF
--- a/kumihan_formatter/core/keyword_parsing/marker_parser.py
+++ b/kumihan_formatter/core/keyword_parsing/marker_parser.py
@@ -468,19 +468,24 @@ class MarkerParser:
             
         start_marker = line[0]
         
+        # ##または＃＃で終わる場合は取り除く
+        working_line = line
+        if working_line.endswith('##') or working_line.endswith('＃＃'):
+            working_line = working_line[:-2].rstrip()
+        
         # 最後の#または＃を探す
         last_hash_pos = -1
-        for i in range(len(line) - 1, 0, -1):
-            if line[i] in ['#', '＃']:
+        for i in range(len(working_line) - 1, 0, -1):
+            if working_line[i] in ['#', '＃']:
                 last_hash_pos = i
                 break
         
         if last_hash_pos == -1 or last_hash_pos == 0:
             return None
             
-        end_marker = line[last_hash_pos]
-        keyword_part = line[1:last_hash_pos].strip()
-        content = line[last_hash_pos + 1:].strip()
+        end_marker = working_line[last_hash_pos]
+        keyword_part = working_line[1:last_hash_pos].strip()
+        content = working_line[last_hash_pos + 1:].strip()
 
         # マーカーの整合性チェック（混在も許可）
         if start_marker not in self.HASH_MARKERS or end_marker not in self.HASH_MARKERS:


### PR DESCRIPTION
## Summary
Issue #706対応: ブロック終了マーカー `##` がキーワード解析を妨害する問題を修正

### 🐛 問題
- `# 太字 # テスト ##` 形式でブロック終了マーカー `##` がキーワード解析に含まれる
- HTML出力で "unknown keyword" エラーが7件発生

### ✅ 修正内容
- `MarkerParser.parse_new_marker_format`メソッドで `##` の前処理を追加
- ブロック終了マーカーを除去してから最後の `#` 文字を検索するよう修正
- キーワード部分とコンテンツ部分の正確な抽出を実現

### 📊 改善結果
- HTML出力での "unknown keyword" エラー: **7件 → 0件**
- マーカー解析の精度向上

### 🧪 Test plan
- [x] 既存テストの通過確認
- [x] `# 太字 # テスト ##` 形式での正常動作確認
- [x] HTML出力エラーの解消確認

🤖 Generated with [Claude Code](https://claude.ai/code)