### PR TITLE
🔧 構文エラー修正: performance_metrics.py と progress_manager.py の構文エラーによりlintが失敗する問題を解決

### DIFF
--- a/kumihan_formatter/core/utilities/performance_metrics.py
+++ b/kumihan_formatter/core/utilities/performance_metrics.py
@@ -383,8 +383,7 @@ class PerformanceMonitor:
                 )
                 report_lines.append(f"  処理速度: {rate_status}")
 
-        return "
-".join(report_lines)
+        return "\n".join(report_lines)
 
     def _calculate_trend(self, values: List[float]) -> float:
         """値の傾向を計算（簡易線形回帰）"""

--- a/kumihan_formatter/core/utilities/progress_manager.py
+++ b/kumihan_formatter/core/utilities/progress_manager.py
@@ -120,25 +120,6 @@ class ProgressManager:
         Args:
             current: 現在の進捗値
             substage: サブステージ名
-            
-=======
-            last_update_time=time.time(),
-        )
-        self.cancelled.clear()
-        self._progress_history.clear()
-
-        self.logger.info(
-            f"Progress tracking started: {total_items} items, stage: {stage}"
-        )
-        self._notify_progress()
-
-    def update(self, current: int, substage: str = "") -> bool:
-        """
-        プログレスを更新
-
-        Args:
-            current: 現在の進捗値
-            substage: サブステージ名
 
         Returns:
             bool: 継続可能な場合True キャンセル時False


### PR DESCRIPTION
## Summary
Issue #721で報告された構文エラーを修正し、`make lint`が正常に実行できるようにしました。

### 修正内容
- **performance_metrics.py:386行目** - 文字列リテラル終端エラーを修正
  - `return "\n".join(report_lines)` の改行文字が不正に分割されていた問題を解決
- **progress_manager.py** - Gitマージ競合マーカーを削除
  - `=======` などの競合マーカーが残存し、docstring構造を破損していた問題を解決

### 検証結果
✅ 構文エラーが解消され、両モジュールが正常にインポート可能  
✅ 基本機能テスト通過（PerformanceMonitor、ProgressManager）  
✅ `make lint`の構文パースエラーが解決  

## Test plan
- [x] Python構文チェック（`python3 -m py_compile`）通過確認
- [x] 基本インポートテスト実行
- [x] 基本機能動作テスト実行
- [x] `make lint`実行でパースエラー解消確認

🤖 Generated with [Claude Code](https://claude.ai/code)