### PR TITLE
feat: Issue #771 - 統一設定管理システムの実装

### DIFF
--- a/examples/config/kumihan.json
+++ b/examples/config/kumihan.json
@@ -1,0 +1,63 @@
+{
+  "config_version": "1.0",
+  "environment": "production",
+  "debug_mode": false,
+  "parallel": {
+    "parallel_threshold_lines": 10000,
+    "parallel_threshold_size": 10485760,
+    "min_chunk_size": 50,
+    "max_chunk_size": 2000,
+    "target_chunks_per_core": 2,
+    "memory_warning_threshold_mb": 150,
+    "memory_critical_threshold_mb": 250,
+    "memory_check_interval": 10,
+    "processing_timeout_seconds": 300,
+    "chunk_timeout_seconds": 30,
+    "enable_progress_callbacks": true,
+    "progress_update_interval": 100,
+    "enable_memory_monitoring": true,
+    "enable_gc_optimization": true
+  },
+  "logging": {
+    "log_level": "INFO",
+    "log_dir": "~/.kumihan/logs",
+    "dev_log_enabled": false,
+    "dev_log_json": false,
+    "log_rotation_when": "midnight",
+    "log_rotation_interval": 1,
+    "log_backup_count": 30,
+    "performance_logging_enabled": true
+  },
+  "error": {
+    "default_level": "normal",
+    "graceful_errors": false,
+    "continue_on_error": false,
+    "show_suggestions": true,
+    "show_statistics": true,
+    "error_display_limit": 10,
+    "max_error_context_lines": 3,
+    "category_settings": {}
+  },
+  "rendering": {
+    "max_width": "800px",
+    "background_color": "#f9f9f9",
+    "container_background": "white",
+    "text_color": "#333",
+    "line_height": "1.8",
+    "font_family": "Hiragino Kaku Gothic ProN, Hiragino Sans, Yu Gothic, Meiryo, sans-serif",
+    "theme_name": "デフォルト",
+    "custom_css": {},
+    "include_source": false,
+    "enable_syntax_highlighting": true
+  },
+  "ui": {
+    "auto_preview": true,
+    "preview_browser": null,
+    "progress_level": "detailed",
+    "progress_style": "bar",
+    "show_progress_tooltip": true,
+    "enable_cancellation": true,
+    "watch_enabled": false,
+    "watch_interval": 1.0
+  }
+}

--- a/examples/config/kumihan.yaml
+++ b/examples/config/kumihan.yaml
@@ -1,0 +1,122 @@
+# Kumihan-Formatter 統一設定ファイルサンプル
+# Issue #771対応: 統一設定管理システム
+
+# 設定バージョン
+config_version: "1.0"
+
+# 実行環境設定
+environment: "development"  # production | development | testing
+debug_mode: true
+
+# 並列処理設定
+parallel:
+  # 並列処理を開始するしきい値
+  parallel_threshold_lines: 15000     # 行数ベース
+  parallel_threshold_size: 20971520   # ファイルサイズベース (20MB)
+  
+  # チャンク分割設定
+  min_chunk_size: 100
+  max_chunk_size: 3000
+  target_chunks_per_core: 3
+  
+  # メモリ監視設定
+  memory_warning_threshold_mb: 200
+  memory_critical_threshold_mb: 350
+  memory_check_interval: 15
+  
+  # タイムアウト設定
+  processing_timeout_seconds: 600     # 10分
+  chunk_timeout_seconds: 60          # 1分
+  
+  # パフォーマンス設定
+  enable_progress_callbacks: true
+  progress_update_interval: 200
+  enable_memory_monitoring: true
+  enable_gc_optimization: true
+
+# ログ設定
+logging:
+  log_level: "DEBUG"                  # DEBUG | INFO | WARNING | ERROR | CRITICAL
+  log_dir: "~/.kumihan/logs"
+  
+  # 開発ログ設定
+  dev_log_enabled: true
+  dev_log_json: false
+  
+  # ローテーション設定
+  log_rotation_when: "midnight"
+  log_rotation_interval: 1
+  log_backup_count: 60                # 2ヶ月分保存
+  
+  # パフォーマンスログ
+  performance_logging_enabled: true
+
+# エラー処理設定
+error:
+  default_level: "normal"             # strict | normal | lenient | ignore
+  
+  # エラー表示設定
+  graceful_errors: true               # HTML埋め込みエラー情報
+  continue_on_error: true             # エラー時処理継続
+  show_suggestions: true              # 修正提案表示
+  show_statistics: true               # エラー統計表示
+  
+  # エラー制限設定
+  error_display_limit: 20
+  max_error_context_lines: 5
+  
+  # カテゴリ別設定
+  category_settings:
+    syntax:
+      level: "normal"
+      continue_on_error: true
+    file_system:
+      level: "strict"
+      continue_on_error: false
+    validation:
+      level: "lenient"
+      continue_on_error: true
+
+# レンダリング設定
+rendering:
+  # CSS設定
+  max_width: "1000px"
+  background_color: "#ffffff"
+  container_background: "#f8f9fa"
+  text_color: "#212529"
+  line_height: "1.75"
+  font_family: "Hiragino Kaku Gothic ProN, Hiragino Sans, Yu Gothic, Meiryo, sans-serif"
+  
+  # テーマ設定
+  theme_name: "開発者テーマ"
+  custom_css:
+    ".code-block": "background-color: #f1f3f4; padding: 1rem; border-radius: 0.5rem;"
+    ".highlight": "background-color: #fff3cd; padding: 0.25rem;"
+  
+  # レンダリング機能
+  include_source: true                # ソース表示機能有効
+  enable_syntax_highlighting: true
+
+# UI設定
+ui:
+  # プレビュー設定
+  auto_preview: true
+  preview_browser: null               # システムデフォルトブラウザを使用
+  
+  # プログレス表示設定
+  progress_level: "verbose"           # silent | minimal | detailed | verbose
+  progress_style: "bar"               # bar | spinner | percentage
+  show_progress_tooltip: true
+  enable_cancellation: true
+  
+  # ファイル監視設定
+  watch_enabled: true
+  watch_interval: 0.5                 # 500ms間隔でチェック
+
+# 環境変数での設定例 (YAMLファイルより優先)
+# KUMIHAN_DEBUG_MODE=true
+# KUMIHAN_PARALLEL__PARALLEL_THRESHOLD_LINES=20000
+# KUMIHAN_LOGGING__LOG_LEVEL=INFO
+# KUMIHAN_ERROR__GRACEFUL_ERRORS=true
+# KUMIHAN_RENDERING__MAX_WIDTH=1200px
+# KUMIHAN_UI__PROGRESS_LEVEL=detailed

--- a/kumihan_formatter/core/unified_config/__init__.py
+++ b/kumihan_formatter/core/unified_config/__init__.py
@@ -1,0 +1,46 @@
+"""統一設定管理システム
+
+Issue #771対応: 分散した設定クラスを統合し、
+一元的な設定管理・環境変数対応・設定ファイル対応を提供
+
+このモジュールは以下を提供:
+- 統一設定管理マネージャー
+- Pydanticベース型安全設定モデル
+- YAML/JSON設定ファイル対応
+- 包括的環境変数サポート
+- ホットリロード機能
+- 既存設定クラスとの互換性
+"""
+
+from .unified_config_manager import UnifiedConfigManager
+from .config_models import (
+    KumihanConfig,
+    ParallelConfig,
+    LoggingConfig,
+    ErrorConfig,
+    RenderingConfig,
+    UIConfig
+)
+from .config_loader import ConfigLoader, ConfigFormat
+from .config_validator import ConfigValidator
+from .config_adapters import (
+    ParallelProcessingConfigAdapter,
+    ErrorConfigManagerAdapter,
+    BaseConfigAdapter
+)
+
+__all__ = [
+    "UnifiedConfigManager",
+    "KumihanConfig",
+    "ParallelConfig", 
+    "LoggingConfig",
+    "ErrorConfig",
+    "RenderingConfig",
+    "UIConfig",
+    "ConfigLoader",
+    "ConfigFormat",
+    "ConfigValidator",
+    "ParallelProcessingConfigAdapter",
+    "ErrorConfigManagerAdapter", 
+    "BaseConfigAdapter",
+]

--- a/kumihan_formatter/core/unified_config/config_adapters.py
+++ b/kumihan_formatter/core/unified_config/config_adapters.py
@@ -1,0 +1,497 @@
+"""統一設定アダプター
+
+Issue #771対応: 既存設定クラスとの互換性を保つアダプター群
+統一設定システムへの移行期間中に旧コードが正常動作するよう支援
+"""
+
+import warnings
+from typing import Any, Dict, Optional, Union
+from pathlib import Path
+
+from ..utilities.logger import get_logger
+from .config_models import KumihanConfig, ParallelConfig, LoggingConfig, ErrorConfig, RenderingConfig
+from .unified_config_manager import get_unified_config_manager
+
+
+class ParallelProcessingConfigAdapter:
+    """ParallelProcessingConfig互換アダプター
+    
+    既存のParallelProcessingConfigクラスの代替として機能
+    統一設定システムから並列処理設定を取得し、旧API形式で提供
+    """
+    
+    def __init__(self, config_manager: Optional[Any] = None):
+        """アダプター初期化
+        
+        Args:
+            config_manager: 統一設定マネージャー (Noneの場合はグローバルを使用)
+        """
+        self.logger = get_logger(__name__)
+        self._config_manager = config_manager or get_unified_config_manager()
+        
+        # 互換性警告の表示
+        warnings.warn(
+            "ParallelProcessingConfigは統一設定システムに統合されました。"
+            "新しいコードではUnifiedConfigManager.get_parallel_config()を使用してください。",
+            DeprecationWarning,
+            stacklevel=2
+        )
+    
+    @property
+    def config(self) -> ParallelConfig:
+        """統一設定から並列処理設定を取得"""
+        return self._config_manager.get_parallel_config()
+    
+    # 旧API互換プロパティ
+    @property
+    def threshold_lines(self) -> int:
+        """並列処理しきい値行数 (旧API互換)"""
+        return self.config.parallel_threshold_lines
+    
+    @property
+    def threshold_size(self) -> int:
+        """並列処理しきい値サイズ (旧API互換)"""
+        return self.config.parallel_threshold_size
+    
+    @property
+    def min_chunk_size(self) -> int:
+        """最小チャンクサイズ"""
+        return self.config.min_chunk_size
+    
+    @property
+    def max_chunk_size(self) -> int:
+        """最大チャンクサイズ"""
+        return self.config.max_chunk_size
+    
+    @property
+    def target_chunks_per_core(self) -> int:
+        """CPUコアあたりのチャンク数"""
+        return self.config.target_chunks_per_core
+    
+    @property
+    def memory_warning_threshold_mb(self) -> int:
+        """メモリ警告しきい値(MB)"""
+        return self.config.memory_warning_threshold_mb
+    
+    @property
+    def memory_critical_threshold_mb(self) -> int:
+        """メモリクリティカルしきい値(MB)"""
+        return self.config.memory_critical_threshold_mb
+    
+    @property
+    def processing_timeout_seconds(self) -> int:
+        """処理タイムアウト(秒)"""
+        return self.config.processing_timeout_seconds
+    
+    # 旧API互換メソッド
+    def should_use_parallel_processing(self, line_count: int, file_size: int) -> bool:
+        """並列処理が必要かチェック (旧API互換)
+        
+        Args:
+            line_count: 行数
+            file_size: ファイルサイズ
+            
+        Returns:
+            bool: 並列処理使用可否
+        """
+        return (line_count >= self.threshold_lines or 
+                file_size >= self.threshold_size)
+    
+    def calculate_chunk_count(self, line_count: int) -> int:
+        """チャンク数計算 (旧API互換)
+        
+        Args:
+            line_count: 総行数
+            
+        Returns:
+            int: 推奨チャンク数
+        """
+        import multiprocessing
+        cpu_count = multiprocessing.cpu_count()
+        
+        # 基本チャンク数
+        base_chunks = max(1, line_count // self.max_chunk_size)
+        
+        # CPUコア数ベースの調整
+        target_chunks = cpu_count * self.target_chunks_per_core
+        
+        return min(base_chunks, target_chunks)
+    
+    def get_chunk_size(self, line_count: int, chunk_count: int) -> int:
+        """チャンクサイズ計算 (旧API互換)
+        
+        Args:
+            line_count: 総行数
+            chunk_count: チャンク数
+            
+        Returns:
+            int: チャンクサイズ
+        """
+        calculated_size = max(1, line_count // chunk_count)
+        return max(self.min_chunk_size, 
+                  min(self.max_chunk_size, calculated_size))
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """設定を辞書形式で返す (旧API互換)"""
+        return self.config.dict()
+
+
+class ErrorConfigManagerAdapter:
+    """ErrorConfigManager互換アダプター
+    
+    既存のErrorConfigManagerクラスの代替として機能
+    統一設定システムからエラー処理設定を取得し、旧API形式で提供
+    """
+    
+    def __init__(self, config_file: Optional[Union[str, Path]] = None):
+        """アダプター初期化
+        
+        Args:
+            config_file: 設定ファイルパス (互換性のため、実際は統一設定を使用)
+        """
+        self.logger = get_logger(__name__)
+        self._config_manager = get_unified_config_manager()
+        
+        # 互換性警告の表示
+        warnings.warn(
+            "ErrorConfigManagerは統一設定システムに統合されました。"
+            "新しいコードではUnifiedConfigManager.get_error_config()を使用してください。",
+            DeprecationWarning,
+            stacklevel=2
+        )
+        
+        # 指定されたconfig_fileは無視（統一設定で管理）
+        if config_file:
+            self.logger.info(f"設定ファイル'{config_file}'は統一設定システムで管理されます")
+    
+    @property
+    def config(self) -> ErrorConfig:
+        """統一設定からエラー処理設定を取得"""
+        return self._config_manager.get_error_config()
+    
+    # 旧API互換プロパティ
+    @property
+    def graceful_errors(self) -> bool:
+        """グレースフルエラー有効"""
+        return self.config.graceful_errors
+    
+    @property
+    def continue_on_error(self) -> bool:
+        """エラー時処理継続"""
+        return self.config.continue_on_error
+    
+    @property
+    def show_suggestions(self) -> bool:
+        """エラー修正提案表示"""
+        return self.config.show_suggestions
+    
+    @property
+    def show_statistics(self) -> bool:
+        """エラー統計表示"""
+        return self.config.show_statistics
+    
+    @property
+    def error_display_limit(self) -> int:
+        """表示エラー数制限"""
+        return self.config.error_display_limit
+    
+    @property
+    def max_error_context_lines(self) -> int:
+        """エラーコンテキスト行数"""
+        return self.config.max_error_context_lines
+    
+    # 旧API互換メソッド
+    def get_error_handling_level(self, category: str = "default") -> str:
+        """エラー処理レベル取得 (旧API互換)
+        
+        Args:
+            category: エラーカテゴリ
+            
+        Returns:
+            str: エラー処理レベル
+        """
+        category_settings = self.config.category_settings.get(category, {})
+        return category_settings.get("level", self.config.default_level.value)
+    
+    def should_continue_on_error(self, category: str = "default") -> bool:
+        """エラー時継続判定 (旧API互換)
+        
+        Args:
+            category: エラーカテゴリ
+            
+        Returns:
+            bool: 継続するかどうか
+        """
+        if category in self.config.category_settings:
+            return self.config.category_settings[category].get(
+                "continue_on_error", self.config.continue_on_error
+            )
+        return self.config.continue_on_error
+    
+    def get_category_settings(self, category: str) -> Dict[str, Any]:
+        """カテゴリ別設定取得 (旧API互換)
+        
+        Args:
+            category: エラーカテゴリ
+            
+        Returns:
+            Dict[str, Any]: カテゴリ設定
+        """
+        return self.config.category_settings.get(category, {})
+    
+    def update_category_settings(self, category: str, settings: Dict[str, Any]) -> None:
+        """カテゴリ別設定更新 (旧API互換)
+        
+        Args:
+            category: エラーカテゴリ
+            settings: 新しい設定
+        """
+        # 統一設定システムでは実際の更新は行わず、警告のみ表示
+        self.logger.warning(
+            f"カテゴリ'{category}'の設定更新は統一設定システムで行ってください。"
+            "実行時の動的更新はサポートされません。"
+        )
+    
+    def save_config(self) -> bool:
+        """設定保存 (旧API互換)
+        
+        Returns:
+            bool: 保存成功フラグ
+        """
+        # 統一設定システムを通じて保存
+        try:
+            return self._config_manager.save_config()
+        except Exception as e:
+            self.logger.error(f"設定保存エラー: {e}")
+            return False
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """設定を辞書形式で返す (旧API互換)"""
+        return self.config.dict()
+
+
+class BaseConfigAdapter:
+    """BaseConfig互換アダプター
+    
+    既存のBaseConfigクラスの代替として機能
+    統一設定システムからレンダリング設定を取得し、旧API形式で提供
+    """
+    
+    def __init__(self):
+        """アダプター初期化"""
+        self.logger = get_logger(__name__)
+        self._config_manager = get_unified_config_manager()
+        
+        # 互換性警告の表示
+        warnings.warn(
+            "BaseConfigは統一設定システムに統合されました。"
+            "新しいコードではUnifiedConfigManager.get_rendering_config()を使用してください。",
+            DeprecationWarning,
+            stacklevel=2
+        )
+    
+    @property
+    def config(self) -> RenderingConfig:
+        """統一設定からレンダリング設定を取得"""
+        return self._config_manager.get_rendering_config()
+    
+    # 旧API互換プロパティ
+    @property
+    def max_width(self) -> str:
+        """最大幅"""
+        return self.config.max_width
+    
+    @property
+    def background_color(self) -> str:
+        """背景色"""
+        return self.config.background_color
+    
+    @property
+    def container_background(self) -> str:
+        """コンテナ背景色"""
+        return self.config.container_background
+    
+    @property
+    def text_color(self) -> str:
+        """テキスト色"""
+        return self.config.text_color
+    
+    @property
+    def line_height(self) -> str:
+        """行の高さ"""
+        return self.config.line_height
+    
+    @property
+    def font_family(self) -> str:
+        """フォントファミリー"""
+        return self.config.font_family
+    
+    @property
+    def theme_name(self) -> str:
+        """テーマ名"""
+        return self.config.theme_name
+    
+    @property
+    def custom_css(self) -> Dict[str, str]:
+        """カスタムCSS"""
+        return self.config.custom_css
+    
+    @property
+    def include_source(self) -> bool:
+        """ソース表示機能"""
+        return self.config.include_source
+    
+    @property
+    def enable_syntax_highlighting(self) -> bool:
+        """構文ハイライト有効"""
+        return self.config.enable_syntax_highlighting
+    
+    # 旧API互換メソッド
+    def get_css_style(self) -> str:
+        """CSS文字列生成 (旧API互換)
+        
+        Returns:
+            str: CSS文字列
+        """
+        css_parts = [
+            f"max-width: {self.max_width};",
+            f"background-color: {self.background_color};",
+            f"color: {self.text_color};",
+            f"line-height: {self.line_height};",
+            f"font-family: {self.font_family};"
+        ]
+        
+        # カスタムCSSの追加
+        for selector, styles in self.custom_css.items():
+            css_parts.append(f"{selector} {{ {styles} }}")
+        
+        return " ".join(css_parts)
+    
+    def get_container_style(self) -> str:
+        """コンテナスタイル取得 (旧API互換)
+        
+        Returns:
+            str: コンテナCSS文字列
+        """
+        return f"background-color: {self.container_background}; max-width: {self.max_width};"
+    
+    def update_theme(self, theme_name: str, theme_settings: Dict[str, str]) -> None:
+        """テーマ更新 (旧API互換)
+        
+        Args:
+            theme_name: テーマ名
+            theme_settings: テーマ設定
+        """
+        # 統一設定システムでは動的更新は制限される
+        self.logger.warning(
+            f"テーマ'{theme_name}'の更新は統一設定システムで行ってください。"
+            "実行時の動的更新はサポートされません。"
+        )
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """設定を辞書形式で返す (旧API互換)"""
+        return self.config.dict()
+
+
+# 互換性ヘルパー関数群
+
+def create_parallel_processing_config(*args, **kwargs) -> ParallelProcessingConfigAdapter:
+    """ParallelProcessingConfig作成ヘルパー (旧API互換)
+    
+    Returns:
+        ParallelProcessingConfigAdapter: アダプターインスタンス
+    """
+    return ParallelProcessingConfigAdapter()
+
+
+def create_error_config_manager(config_file: Optional[Union[str, Path]] = None) -> ErrorConfigManagerAdapter:
+    """ErrorConfigManager作成ヘルパー (旧API互換)
+    
+    Args:
+        config_file: 設定ファイルパス
+        
+    Returns:
+        ErrorConfigManagerAdapter: アダプターインスタンス
+    """
+    return ErrorConfigManagerAdapter(config_file)
+
+
+def create_base_config() -> BaseConfigAdapter:
+    """BaseConfig作成ヘルパー (旧API互換)
+    
+    Returns:
+        BaseConfigAdapter: アダプターインスタンス
+    """
+    return BaseConfigAdapter()
+
+
+# 移行支援関数
+
+def migrate_config_usage(old_config_type: str) -> str:
+    """設定クラス移行ガイダンス
+    
+    Args:
+        old_config_type: 旧設定クラス名
+        
+    Returns:
+        str: 移行ガイド文字列
+    """
+    migration_guides = {
+        "ParallelProcessingConfig": (
+            "# 旧コード:\n"
+            "config = ParallelProcessingConfig()\n"
+            "threshold = config.threshold_lines\n\n"
+            "# 新コード:\n"
+            "from kumihan_formatter.core.unified_config import get_unified_config_manager\n"
+            "manager = get_unified_config_manager()\n"
+            "threshold = manager.get_parallel_config().parallel_threshold_lines"
+        ),
+        "ErrorConfigManager": (
+            "# 旧コード:\n"
+            "manager = ErrorConfigManager('config.yaml')\n"
+            "graceful = manager.graceful_errors\n\n"
+            "# 新コード:\n"
+            "from kumihan_formatter.core.unified_config import get_unified_config_manager\n"
+            "manager = get_unified_config_manager()\n"
+            "graceful = manager.get_error_config().graceful_errors"
+        ),
+        "BaseConfig": (
+            "# 旧コード:\n"
+            "config = BaseConfig()\n"
+            "width = config.max_width\n\n"
+            "# 新コード:\n" 
+            "from kumihan_formatter.core.unified_config import get_unified_config_manager\n"
+            "manager = get_unified_config_manager()\n"
+            "width = manager.get_rendering_config().max_width"
+        )
+    }
+    
+    return migration_guides.get(old_config_type, "該当する移行ガイドが見つかりません")
+
+
+def check_config_compatibility() -> Dict[str, bool]:
+    """設定互換性チェック
+    
+    Returns:
+        Dict[str, bool]: 各設定クラスの互換性状況
+    """
+    compatibility_status = {}
+    
+    try:
+        # 統一設定マネージャーの動作確認
+        manager = get_unified_config_manager()
+        config = manager.get_config()
+        
+        compatibility_status["unified_config"] = True
+        compatibility_status["parallel_config"] = bool(config.parallel)
+        compatibility_status["logging_config"] = bool(config.logging)
+        compatibility_status["error_config"] = bool(config.error)
+        compatibility_status["rendering_config"] = bool(config.rendering)
+        compatibility_status["ui_config"] = bool(config.ui)
+        
+    except Exception as e:
+        logger = get_logger(__name__)
+        logger.error(f"設定互換性チェックエラー: {e}")
+        compatibility_status["error"] = str(e)
+    
+    return compatibility_status

--- a/kumihan_formatter/core/unified_config/config_loader.py
+++ b/kumihan_formatter/core/unified_config/config_loader.py
@@ -1,0 +1,360 @@
+"""統一設定ローダー
+
+Issue #771対応: YAML/JSON/TOML設定ファイル対応
+環境変数・CLI引数・設定ファイルの優先順位制御
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
+try:
+    import tomli
+    HAS_TOML = True
+except ImportError:
+    HAS_TOML = False
+
+from ..utilities.logger import get_logger
+from ..error_handling import handle_error_unified
+from .config_models import ConfigFormat, KumihanConfig
+
+
+class ConfigLoadError(Exception):
+    """設定読み込みエラー"""
+    pass
+
+
+class ConfigLoader:
+    """統一設定ローダー
+    
+    設定の読み込み優先順位:
+    1. CLI引数 (最優先)
+    2. 環境変数
+    3. 設定ファイル
+    4. デフォルト値
+    """
+    
+    def __init__(self, logger_name: str = __name__):
+        self.logger = get_logger(logger_name)
+        self.supported_formats = self._get_supported_formats()
+        
+    def _get_supported_formats(self) -> List[ConfigFormat]:
+        """サポートされている設定ファイル形式を取得"""
+        formats = [ConfigFormat.JSON]  # JSONは標準ライブラリなので常にサポート
+        
+        if HAS_YAML:
+            formats.extend([ConfigFormat.YAML])
+        if HAS_TOML:
+            formats.append(ConfigFormat.TOML)
+            
+        return formats
+    
+    def load_from_file(self, config_path: Union[str, Path]) -> Dict[str, Any]:
+        """設定ファイルから設定を読み込み
+        
+        Args:
+            config_path: 設定ファイルパス
+            
+        Returns:
+            Dict[str, Any]: 設定データ
+            
+        Raises:
+            ConfigLoadError: 設定ファイル読み込みエラー
+        """
+        config_file = Path(config_path)
+        
+        if not config_file.exists():
+            raise ConfigLoadError(f"設定ファイルが見つかりません: {config_path}")
+            
+        if not config_file.is_file():
+            raise ConfigLoadError(f"設定パスがファイルではありません: {config_path}")
+        
+        # ファイル形式の判定
+        file_format = self._detect_format(config_file)
+        
+        try:
+            with open(config_file, 'r', encoding='utf-8') as f:
+                if file_format == ConfigFormat.YAML:
+                    if not HAS_YAML:
+                        raise ConfigLoadError("YAML設定ファイルの読み込みにはPyYAMLが必要です")
+                    config_data = yaml.safe_load(f)
+                    
+                elif file_format == ConfigFormat.JSON:
+                    config_data = json.load(f)
+                    
+                elif file_format == ConfigFormat.TOML:
+                    if not HAS_TOML:
+                        raise ConfigLoadError("TOML設定ファイルの読み込みにはtomliが必要です")
+                    # TOMLはバイナリモードで読む必要がある
+                    f.close()
+                    with open(config_file, 'rb') as fb:
+                        config_data = tomli.load(fb)
+                    
+                else:
+                    raise ConfigLoadError(f"未サポートの設定ファイル形式: {file_format}")
+                    
+            if not isinstance(config_data, dict):
+                raise ConfigLoadError("設定ファイルは辞書形式である必要があります")
+                
+            self.logger.info(f"設定ファイル読み込み成功: {config_path} ({file_format.value})")
+            return config_data
+            
+        except (yaml.YAMLError, json.JSONDecodeError, Exception) as e:
+            error_msg = f"設定ファイル解析エラー: {config_path}: {e}"
+            self.logger.error(error_msg)
+            
+            # 統一エラーハンドリングで処理
+            try:
+                result = handle_error_unified(
+                    e,
+                    context={
+                        "config_path": str(config_path),
+                        "file_format": file_format.value,
+                        "operation": "config_file_loading"
+                    },
+                    operation="load_config_file",
+                    component_name="ConfigLoader"
+                )
+                raise ConfigLoadError(error_msg) from e
+            except Exception:
+                raise ConfigLoadError(error_msg) from e
+    
+    def _detect_format(self, config_file: Path) -> ConfigFormat:
+        """ファイル拡張子から設定ファイル形式を判定
+        
+        Args:
+            config_file: 設定ファイルパス
+            
+        Returns:
+            ConfigFormat: 判定された形式
+            
+        Raises:
+            ConfigLoadError: サポートされていない形式
+        """
+        suffix = config_file.suffix.lower()
+        
+        if suffix in ['.yaml', '.yml']:
+            if not HAS_YAML:
+                raise ConfigLoadError("YAML形式はサポートされていません (PyYAMLが必要)")
+            return ConfigFormat.YAML
+            
+        elif suffix == '.json':
+            return ConfigFormat.JSON
+            
+        elif suffix == '.toml':
+            if not HAS_TOML:
+                raise ConfigLoadError("TOML形式はサポートされていません (tomliが必要)")
+            return ConfigFormat.TOML
+            
+        else:
+            raise ConfigLoadError(f"未サポートの設定ファイル拡張子: {suffix}")
+    
+    def load_from_environment(self, prefix: str = "KUMIHAN_") -> Dict[str, Any]:
+        """環境変数から設定を読み込み
+        
+        Args:
+            prefix: 環境変数プレフィックス
+            
+        Returns:
+            Dict[str, Any]: 環境変数から読み込んだ設定
+        """
+        config_data = {}
+        
+        for key, value in os.environ.items():
+            if key.startswith(prefix):
+                # プレフィックスを除去
+                config_key = key[len(prefix):].lower()
+                
+                # ネストした設定対応 (例: KUMIHAN_PARALLEL__THRESHOLD_LINES)
+                if '__' in config_key:
+                    keys = config_key.split('__')
+                    self._set_nested_value(config_data, keys, self._convert_env_value(value))
+                else:
+                    config_data[config_key] = self._convert_env_value(value)
+        
+        if config_data:
+            self.logger.debug(f"環境変数から設定読み込み: {len(config_data)}項目")
+            
+        return config_data
+    
+    def _set_nested_value(self, data: Dict[str, Any], keys: List[str], value: Any) -> None:
+        """ネストした辞書に値を設定
+        
+        Args:
+            data: 対象辞書
+            keys: キーのリスト
+            value: 設定値
+        """
+        current = data
+        for key in keys[:-1]:
+            if key not in current:
+                current[key] = {}
+            current = current[key]
+        current[keys[-1]] = value
+    
+    def _convert_env_value(self, value: str) -> Union[str, int, float, bool]:
+        """環境変数値を適切な型に変換
+        
+        Args:
+            value: 環境変数値
+            
+        Returns:
+            Union[str, int, float, bool]: 変換された値
+        """
+        # ブール値の変換
+        if value.lower() in ('true', '1', 'yes', 'on'):
+            return True
+        elif value.lower() in ('false', '0', 'no', 'off'):
+            return False
+        
+        # 数値の変換
+        try:
+            # 整数の場合
+            if '.' not in value:
+                return int(value)
+            # 浮動小数点数の場合
+            else:
+                return float(value)
+        except ValueError:
+            # 文字列のまま返す
+            return value
+    
+    def find_config_file(self, 
+                        search_paths: Optional[List[Union[str, Path]]] = None,
+                        filename_patterns: Optional[List[str]] = None) -> Optional[Path]:
+        """設定ファイルを検索
+        
+        Args:
+            search_paths: 検索パスリスト
+            filename_patterns: ファイル名パターンリスト
+            
+        Returns:
+            Optional[Path]: 見つかった設定ファイルパス
+        """
+        if search_paths is None:
+            search_paths = [
+                Path.cwd(),  # カレントディレクトリ
+                Path.home() / '.kumihan',  # ユーザーホーム/.kumihan
+                Path.home() / '.config' / 'kumihan',  # XDG Config
+                Path('/etc/kumihan') if sys.platform != 'win32' else Path(),  # システム設定
+            ]
+        
+        if filename_patterns is None:
+            filename_patterns = [
+                'kumihan.yaml', 'kumihan.yml',
+                'kumihan.json',
+                'kumihan.toml',
+                '.kumihan.yaml', '.kumihan.yml',
+                '.kumihan.json',
+                '.kumihan.toml'
+            ]
+        
+        for search_path in search_paths:
+            if not isinstance(search_path, Path):
+                search_path = Path(search_path)
+                
+            if not search_path.exists():
+                continue
+                
+            for pattern in filename_patterns:
+                config_file = search_path / pattern
+                if config_file.exists() and config_file.is_file():
+                    self.logger.info(f"設定ファイル発見: {config_file}")
+                    return config_file
+        
+        self.logger.debug("設定ファイルが見つかりませんでした")
+        return None
+    
+    def merge_configs(self, *configs: Dict[str, Any]) -> Dict[str, Any]:
+        """複数の設定を優先順位に従ってマージ
+        
+        Args:
+            *configs: 設定辞書群 (後の引数ほど優先度が高い)
+            
+        Returns:
+            Dict[str, Any]: マージされた設定
+        """
+        merged = {}
+        
+        for config in configs:
+            if config:
+                merged = self._deep_merge(merged, config)
+        
+        return merged
+    
+    def _deep_merge(self, base: Dict[str, Any], update: Dict[str, Any]) -> Dict[str, Any]:
+        """辞書の深いマージ
+        
+        Args:
+            base: ベース辞書
+            update: 更新辞書
+            
+        Returns:
+            Dict[str, Any]: マージされた辞書
+        """
+        result = base.copy()
+        
+        for key, value in update.items():
+            if (key in result and 
+                isinstance(result[key], dict) and 
+                isinstance(value, dict)):
+                result[key] = self._deep_merge(result[key], value)
+            else:
+                result[key] = value
+                
+        return result
+    
+    def save_config(self, 
+                   config: KumihanConfig, 
+                   config_path: Union[str, Path],
+                   format: Optional[ConfigFormat] = None) -> None:
+        """設定をファイルに保存
+        
+        Args:
+            config: 保存する設定
+            config_path: 保存先パス
+            format: 保存形式 (Noneの場合は拡張子から判定)
+            
+        Raises:
+            ConfigLoadError: 保存エラー
+        """
+        config_file = Path(config_path)
+        
+        if format is None:
+            format = self._detect_format(config_file)
+        
+        # ディレクトリが存在しない場合は作成
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        
+        try:
+            config_data = config.dict()
+            
+            with open(config_file, 'w', encoding='utf-8') as f:
+                if format == ConfigFormat.YAML:
+                    if not HAS_YAML:
+                        raise ConfigLoadError("YAML保存にはPyYAMLが必要です")
+                    yaml.dump(config_data, f, default_flow_style=False, allow_unicode=True)
+                    
+                elif format == ConfigFormat.JSON:
+                    json.dump(config_data, f, indent=2, ensure_ascii=False)
+                    
+                elif format == ConfigFormat.TOML:
+                    raise ConfigLoadError("TOML形式での保存は現在サポートされていません")
+                    
+                else:
+                    raise ConfigLoadError(f"未サポートの保存形式: {format}")
+            
+            self.logger.info(f"設定保存完了: {config_path} ({format.value})")
+            
+        except Exception as e:
+            error_msg = f"設定保存エラー: {config_path}: {e}"
+            self.logger.error(error_msg)
+            raise ConfigLoadError(error_msg) from e

--- a/kumihan_formatter/core/unified_config/config_models.py
+++ b/kumihan_formatter/core/unified_config/config_models.py
@@ -1,0 +1,305 @@
+"""統一設定モデル
+
+Issue #771対応: Pydanticベースの型安全な設定モデル群
+既存の分散設定クラスを統合し、一元的な設定管理を実現
+"""
+
+import os
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from pydantic import BaseModel, Field, field_validator, model_validator, ConfigDict
+
+from ..common.error_types import ErrorSeverity, ErrorCategory
+
+
+class ConfigFormat(str, Enum):
+    """サポートする設定ファイル形式"""
+    YAML = "yaml"
+    JSON = "json"
+    TOML = "toml"
+
+
+class LogLevel(str, Enum):
+    """ログレベル"""
+    DEBUG = "DEBUG"
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+    CRITICAL = "CRITICAL"
+
+
+class ErrorHandlingLevel(str, Enum):
+    """エラー処理レベル"""
+    STRICT = "strict"
+    NORMAL = "normal"
+    LENIENT = "lenient"
+    IGNORE = "ignore"
+
+
+class ParallelConfig(BaseModel):
+    """並列処理設定
+    
+    ParallelProcessingConfigの統一版
+    """
+    # 並列処理しきい値
+    parallel_threshold_lines: int = Field(
+        default=10000,
+        ge=1000,
+        description="並列処理を開始する行数のしきい値"
+    )
+    parallel_threshold_size: int = Field(
+        default=10 * 1024 * 1024,  # 10MB
+        ge=1024 * 1024,  # 1MB
+        description="並列処理を開始するファイルサイズのしきい値(bytes)"
+    )
+    
+    # チャンク設定
+    min_chunk_size: int = Field(default=50, ge=10, description="最小チャンクサイズ")
+    max_chunk_size: int = Field(default=2000, le=10000, description="最大チャンクサイズ")
+    target_chunks_per_core: int = Field(
+        default=2, ge=1, le=10, description="CPUコアあたりのチャンク数"
+    )
+    
+    # メモリ監視
+    memory_warning_threshold_mb: int = Field(
+        default=150, ge=50, description="メモリ警告しきい値(MB)"
+    )
+    memory_critical_threshold_mb: int = Field(
+        default=250, ge=100, description="メモリクリティカルしきい値(MB)"
+    )
+    memory_check_interval: int = Field(
+        default=10, ge=1, description="メモリチェック間隔(チャンク数)"
+    )
+    
+    # タイムアウト設定
+    processing_timeout_seconds: int = Field(
+        default=300, ge=10, description="処理タイムアウト(秒)"
+    )
+    chunk_timeout_seconds: int = Field(
+        default=30, ge=5, description="チャンクタイムアウト(秒)"
+    )
+    
+    # パフォーマンス設定
+    enable_progress_callbacks: bool = Field(
+        default=True, description="プログレスコールバック有効"
+    )
+    progress_update_interval: int = Field(
+        default=100, ge=10, description="プログレス更新間隔(行数)"
+    )
+    enable_memory_monitoring: bool = Field(
+        default=True, description="メモリ監視有効"
+    )
+    enable_gc_optimization: bool = Field(
+        default=True, description="GC最適化有効"
+    )
+    
+    @field_validator('max_chunk_size')
+    @classmethod
+    def validate_chunk_sizes(cls, v, info):
+        """チャンクサイズの整合性チェック"""
+        if hasattr(info, 'data') and 'min_chunk_size' in info.data and v <= info.data['min_chunk_size']:
+            raise ValueError('max_chunk_size must be greater than min_chunk_size')
+        return v
+    
+    @field_validator('memory_critical_threshold_mb')
+    @classmethod
+    def validate_memory_thresholds(cls, v, info):
+        """メモリしきい値の整合性チェック"""
+        if hasattr(info, 'data') and 'memory_warning_threshold_mb' in info.data and v <= info.data['memory_warning_threshold_mb']:
+            raise ValueError('memory_critical_threshold_mb must be greater than memory_warning_threshold_mb')
+        return v
+
+    model_config = ConfigDict(env_prefix="KUMIHAN_PARALLEL_")
+
+
+class LoggingConfig(BaseModel):
+    """ログ設定
+    
+    KumihanLoggerの統一版
+    """
+    log_level: LogLevel = Field(default=LogLevel.INFO, description="ログレベル")
+    log_dir: Path = Field(
+        default_factory=lambda: Path.home() / ".kumihan" / "logs",
+        description="ログディレクトリ"
+    )
+    
+    # 開発ログ設定
+    dev_log_enabled: bool = Field(default=False, description="開発ログ有効")
+    dev_log_json: bool = Field(default=False, description="開発ログJSON形式")
+    
+    # ファイルローテーション設定
+    log_rotation_when: str = Field(default="midnight", description="ログローテーション頻度")
+    log_rotation_interval: int = Field(default=1, ge=1, description="ローテーション間隔")
+    log_backup_count: int = Field(default=30, ge=1, description="バックアップファイル数")
+    
+    # パフォーマンスログ設定
+    performance_logging_enabled: bool = Field(
+        default=True, description="パフォーマンスログ有効"
+    )
+    
+    model_config = ConfigDict(env_prefix="KUMIHAN_LOG_")
+
+
+class ErrorConfig(BaseModel):
+    """エラー処理設定
+    
+    ErrorConfigManagerの統一版
+    """
+    default_level: ErrorHandlingLevel = Field(
+        default=ErrorHandlingLevel.NORMAL, description="デフォルトエラー処理レベル"
+    )
+    
+    # エラー表示設定
+    graceful_errors: bool = Field(
+        default=False, description="エラー情報HTML埋め込み"
+    )
+    continue_on_error: bool = Field(
+        default=False, description="エラー時処理継続"
+    )
+    show_suggestions: bool = Field(
+        default=True, description="エラー修正提案表示"
+    )
+    show_statistics: bool = Field(
+        default=True, description="エラー統計表示"
+    )
+    
+    # エラー制限設定
+    error_display_limit: int = Field(
+        default=10, ge=1, description="表示エラー数制限"
+    )
+    max_error_context_lines: int = Field(
+        default=3, ge=0, description="エラーコンテキスト行数"
+    )
+    
+    # カテゴリ別設定
+    category_settings: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict, description="カテゴリ別エラー設定"
+    )
+    
+    model_config = ConfigDict(env_prefix="KUMIHAN_ERROR_")
+
+
+class RenderingConfig(BaseModel):
+    """レンダリング設定
+    
+    BaseConfigのCSS設定等を統合
+    """
+    # CSS設定
+    max_width: str = Field(default="800px", description="最大幅")
+    background_color: str = Field(default="#f9f9f9", description="背景色")
+    container_background: str = Field(default="white", description="コンテナ背景色")
+    text_color: str = Field(default="#333", description="テキスト色")
+    line_height: str = Field(default="1.8", description="行の高さ")
+    font_family: str = Field(
+        default="Hiragino Kaku Gothic ProN, Hiragino Sans, Yu Gothic, Meiryo, sans-serif",
+        description="フォントファミリー"
+    )
+    
+    # テーマ設定
+    theme_name: str = Field(default="デフォルト", description="テーマ名")
+    custom_css: Dict[str, str] = Field(
+        default_factory=dict, description="カスタムCSS"
+    )
+    
+    # レンダリング設定
+    include_source: bool = Field(default=False, description="ソース表示機能")
+    enable_syntax_highlighting: bool = Field(
+        default=True, description="構文ハイライト有効"
+    )
+    
+    model_config = ConfigDict(env_prefix="KUMIHAN_RENDER_")
+
+
+class UIConfig(BaseModel):
+    """UI設定
+    
+    GUI・CLI関連設定の統合
+    """
+    # プレビュー設定
+    auto_preview: bool = Field(default=True, description="自動プレビュー")
+    preview_browser: Optional[str] = Field(default=None, description="プレビューブラウザ")
+    
+    # プログレス表示設定
+    progress_level: str = Field(
+        default="detailed",
+        pattern="^(silent|minimal|detailed|verbose)$",
+        description="プログレス表示レベル"
+    )
+    progress_style: str = Field(
+        default="bar",
+        pattern="^(bar|spinner|percentage)$", 
+        description="プログレス表示スタイル"
+    )
+    show_progress_tooltip: bool = Field(
+        default=True, description="プログレスツールチップ表示"
+    )
+    enable_cancellation: bool = Field(
+        default=True, description="キャンセル機能有効"
+    )
+    
+    # ファイル監視設定
+    watch_enabled: bool = Field(default=False, description="ファイル監視有効")
+    watch_interval: float = Field(default=1.0, ge=0.1, description="監視間隔(秒)")
+    
+    model_config = ConfigDict(env_prefix="KUMIHAN_UI_")
+
+
+class KumihanConfig(BaseModel):
+    """Kumihan-Formatter統一設定
+    
+    全設定の最上位コンテナ
+    """
+    # サブ設定群
+    parallel: ParallelConfig = Field(default_factory=ParallelConfig)
+    logging: LoggingConfig = Field(default_factory=LoggingConfig)
+    error: ErrorConfig = Field(default_factory=ErrorConfig)
+    rendering: RenderingConfig = Field(default_factory=RenderingConfig)
+    ui: UIConfig = Field(default_factory=UIConfig)
+    
+    # メタ設定
+    config_version: str = Field(default="1.0", description="設定バージョン")
+    config_file_path: Optional[Path] = Field(default=None, description="設定ファイルパス")
+    last_updated: Optional[str] = Field(default=None, description="最終更新日時")
+    
+    # 環境情報
+    environment: str = Field(default="production", description="実行環境")
+    debug_mode: bool = Field(default=False, description="デバッグモード")
+    
+    @model_validator(mode='before')
+    @classmethod
+    def validate_config_consistency(cls, values):
+        """設定間の整合性チェック"""
+        # ログレベルとデバッグモードの整合性
+        if values.get('debug_mode') and values.get('logging'):
+            logging_dict = values['logging']
+            if isinstance(logging_dict, dict):
+                if logging_dict.get('log_level') not in ['DEBUG', 'INFO']:
+                    logging_dict['log_level'] = 'DEBUG'
+                
+        return values
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """辞書形式で設定を出力"""
+        return self.dict()
+    
+    def get_env_vars(self) -> Dict[str, str]:
+        """現在の設定から環境変数を生成"""
+        env_vars = {}
+        
+        # 各サブ設定から環境変数を抽出
+        for field_name, field_value in self.dict().items():
+            if isinstance(field_value, dict):
+                prefix = f"KUMIHAN_{field_name.upper()}_"
+                for key, value in field_value.items():
+                    env_key = f"{prefix}{key.upper()}"
+                    env_vars[env_key] = str(value)
+                    
+        return env_vars
+    
+    model_config = ConfigDict(
+        validate_assignment=True,
+        extra="forbid",
+        env_nested_delimiter="__",
+        case_sensitive=False
+    )

--- a/kumihan_formatter/core/unified_config/config_validator.py
+++ b/kumihan_formatter/core/unified_config/config_validator.py
@@ -1,0 +1,418 @@
+"""統一設定バリデーター
+
+Issue #771対応: 設定値の包括的検証と修正提案
+Pydanticの検証機能を拡張し、Kumihan特有の検証ルールを実装
+"""
+
+import re
+import socket
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from pydantic import ValidationError
+
+from ..utilities.logger import get_logger
+from ..error_handling import handle_error_unified
+from .config_models import KumihanConfig, ParallelConfig, LoggingConfig, ErrorConfig
+
+
+class ConfigValidationError(Exception):
+    """設定検証エラー"""
+    pass
+
+
+class ValidationResult:
+    """検証結果"""
+    
+    def __init__(self):
+        self.is_valid: bool = True
+        self.errors: List[str] = []
+        self.warnings: List[str] = []
+        self.suggestions: List[str] = []
+        self.fixed_config: Optional[KumihanConfig] = None
+    
+    def add_error(self, message: str) -> None:
+        """エラーを追加"""
+        self.is_valid = False
+        self.errors.append(message)
+    
+    def add_warning(self, message: str) -> None:
+        """警告を追加"""
+        self.warnings.append(message)
+    
+    def add_suggestion(self, message: str) -> None:
+        """提案を追加"""
+        self.suggestions.append(message)
+    
+    def has_issues(self) -> bool:
+        """何らかの問題があるかチェック"""
+        return len(self.errors) > 0 or len(self.warnings) > 0
+
+
+class ConfigValidator:
+    """統一設定バリデーター
+    
+    Pydanticの基本検証に加えて、Kumihan特有の検証ルールを実装
+    """
+    
+    def __init__(self, logger_name: str = __name__):
+        self.logger = get_logger(logger_name)
+    
+    def validate_config(self, 
+                       config_data: Dict[str, Any],
+                       auto_fix: bool = False) -> ValidationResult:
+        """設定の包括的検証
+        
+        Args:
+            config_data: 検証する設定データ
+            auto_fix: 自動修正を試行するか
+            
+        Returns:
+            ValidationResult: 検証結果
+        """
+        result = ValidationResult()
+        
+        try:
+            # 1. Pydanticレベルの基本検証
+            config = KumihanConfig(**config_data)
+            result.fixed_config = config
+            
+            # 2. Kumihan特有の検証ルール
+            self._validate_parallel_config(config.parallel, result)
+            self._validate_logging_config(config.logging, result)
+            self._validate_error_config(config.error, result)
+            self._validate_rendering_config(config.rendering, result)
+            self._validate_ui_config(config.ui, result)
+            
+            # 3. 設定間の依存関係検証
+            self._validate_config_dependencies(config, result)
+            
+            # 4. システム環境との整合性検証
+            self._validate_system_compatibility(config, result)
+            
+            # 5. 自動修正処理
+            if auto_fix and result.has_issues():
+                result.fixed_config = self._apply_auto_fixes(config, result)
+            
+            if result.is_valid:
+                self.logger.info("設定検証完了: 問題なし")
+            else:
+                self.logger.warning(f"設定検証完了: {len(result.errors)}個のエラー、{len(result.warnings)}個の警告")
+                
+        except ValidationError as e:
+            # Pydantic検証エラーの処理
+            for error in e.errors():
+                field_path = " -> ".join(str(loc) for loc in error['loc'])
+                error_msg = f"{field_path}: {error['msg']}"
+                result.add_error(error_msg)
+                
+                # 修正提案の生成
+                suggestion = self._generate_validation_suggestion(error)
+                if suggestion:
+                    result.add_suggestion(suggestion)
+            
+            # 統一エラーハンドリングでログ出力
+            try:
+                handle_error_unified(
+                    e,
+                    context={"validation_errors": len(e.errors())},
+                    operation="config_validation",
+                    component_name="ConfigValidator"
+                )
+            except Exception:
+                pass  # エラーハンドリング自体のエラーは無視
+                
+        except Exception as e:
+            result.add_error(f"設定検証中に予期しないエラー: {e}")
+            self.logger.error(f"設定検証エラー: {e}", exc_info=True)
+        
+        return result
+    
+    def _validate_parallel_config(self, 
+                                 config: ParallelConfig, 
+                                 result: ValidationResult) -> None:
+        """並列処理設定の検証"""
+        
+        # CPUコア数との整合性チェック
+        try:
+            import multiprocessing
+            cpu_count = multiprocessing.cpu_count()
+            
+            max_reasonable_chunks = cpu_count * 4  # CPUコア数の4倍まで
+            if config.target_chunks_per_core * cpu_count > max_reasonable_chunks:
+                result.add_warning(
+                    f"チャンク数が多すぎる可能性があります "
+                    f"(CPU{cpu_count}コア, {config.target_chunks_per_core}チャンク/コア)"
+                )
+                result.add_suggestion(f"target_chunks_per_core を {max_reasonable_chunks // cpu_count} 以下に設定することを推奨")
+                
+        except Exception:
+            pass  # multiprocessing取得失敗は無視
+        
+        # メモリ設定の妥当性チェック
+        if config.memory_critical_threshold_mb > 1024:  # 1GB
+            result.add_warning("メモリクリティカルしきい値が非常に高く設定されています")
+            result.add_suggestion("通常は500MB以下の設定を推奨")
+        
+        # タイムアウト設定の妥当性
+        if config.processing_timeout_seconds < 60:
+            result.add_warning("処理タイムアウトが短すぎる可能性があります")
+            result.add_suggestion("大きなファイル処理を考慮して300秒以上を推奨")
+    
+    def _validate_logging_config(self, 
+                                config: LoggingConfig, 
+                                result: ValidationResult) -> None:
+        """ログ設定の検証"""
+        
+        # ログディレクトリの書き込み権限チェック
+        try:
+            config.log_dir.mkdir(parents=True, exist_ok=True)
+            test_file = config.log_dir / ".write_test"
+            test_file.write_text("test")
+            test_file.unlink()
+            
+        except PermissionError:
+            result.add_error(f"ログディレクトリに書き込み権限がありません: {config.log_dir}")
+            result.add_suggestion("ログディレクトリを書き込み可能な場所に変更してください")
+            
+        except Exception as e:
+            result.add_warning(f"ログディレクトリ検証でエラー: {e}")
+        
+        # バックアップ数の妥当性
+        if config.log_backup_count > 365:
+            result.add_warning("ログバックアップ数が多すぎます")
+            result.add_suggestion("通常は30-90日分のバックアップで十分です")
+        
+        # ディスク容量への配慮
+        if config.log_backup_count > 100:
+            result.add_suggestion("多数のログファイルはディスク容量に注意してください")
+    
+    def _validate_error_config(self, 
+                              config: ErrorConfig, 
+                              result: ValidationResult) -> None:
+        """エラー設定の検証"""
+        
+        # エラー表示制限の妥当性
+        if config.error_display_limit > 100:
+            result.add_warning("エラー表示制限が多すぎます")
+            result.add_suggestion("通常は10-20個程度の表示で十分です")
+        
+        # graceful_errorsとcontinue_on_errorの組み合わせ
+        if config.graceful_errors and not config.continue_on_error:
+            result.add_suggestion(
+                "graceful_errorsを有効にする場合、continue_on_errorも有効にすることを推奨"
+            )
+        
+        # カテゴリ別設定の検証
+        for category, settings in config.category_settings.items():
+            if not isinstance(settings, dict):
+                result.add_error(f"カテゴリ設定は辞書である必要があります: {category}")
+    
+    def _validate_rendering_config(self, 
+                                  config: Any,  # RenderingConfig
+                                  result: ValidationResult) -> None:
+        """レンダリング設定の検証"""
+        
+        # CSS値の基本的な検証
+        if not self._is_valid_css_value(config.max_width):
+            result.add_error(f"無効なCSS値: max_width = {config.max_width}")
+            result.add_suggestion("例: '800px', '90%', 'auto' など")
+        
+        # 色の値の検証
+        if not self._is_valid_color(config.background_color):
+            result.add_error(f"無効な色値: background_color = {config.background_color}")
+            result.add_suggestion("例: '#f9f9f9', 'white', 'rgb(255,255,255)' など")
+        
+        if not self._is_valid_color(config.container_background):
+            result.add_error(f"無効な色値: container_background = {config.container_background}")
+        
+        if not self._is_valid_color(config.text_color):
+            result.add_error(f"無効な色値: text_color = {config.text_color}")
+        
+        # フォントファミリーの検証
+        if not config.font_family.strip():
+            result.add_error("フォントファミリーが空です")
+            result.add_suggestion("デフォルトのフォントファミリーを設定してください")
+    
+    def _validate_ui_config(self, 
+                           config: Any,  # UIConfig
+                           result: ValidationResult) -> None:
+        """UI設定の検証"""
+        
+        # プレビューブラウザの検証
+        if config.preview_browser:
+            if not self._is_valid_browser_command(config.preview_browser):
+                result.add_warning(f"指定されたブラウザが見つからない可能性があります: {config.preview_browser}")
+                result.add_suggestion("システムにインストールされているブラウザを指定してください")
+        
+        # 監視間隔の妥当性
+        if config.watch_interval < 0.1:
+            result.add_error("ファイル監視間隔が短すぎます")
+            result.add_suggestion("0.1秒以上の間隔を設定してください")
+        
+        if config.watch_interval > 60:
+            result.add_warning("ファイル監視間隔が長すぎます")
+            result.add_suggestion("通常は1-5秒程度が適切です")
+    
+    def _validate_config_dependencies(self, 
+                                     config: KumihanConfig, 
+                                     result: ValidationResult) -> None:
+        """設定間の依存関係検証"""
+        
+        # デバッグモードとログレベルの整合性
+        if config.debug_mode and config.logging.log_level.value not in ['DEBUG', 'INFO']:
+            result.add_suggestion("デバッグモード時はログレベルをDEBUGまたはINFOに設定することを推奨")
+        
+        # エラー処理とログ設定の整合性
+        if config.error.graceful_errors and config.logging.log_level.value == 'ERROR':
+            result.add_suggestion("graceful_errorsを使用する場合、詳細なログのためINFOレベルを推奨")
+        
+        # 並列処理とメモリ設定の整合性
+        estimated_memory_mb = (
+            config.parallel.max_chunk_size * 
+            config.parallel.target_chunks_per_core * 
+            4  # 推定メモリ使用量
+        ) // 1024
+        
+        if estimated_memory_mb > config.parallel.memory_warning_threshold_mb:
+            result.add_warning("並列処理設定がメモリ制限を超える可能性があります")
+            result.add_suggestion(f"メモリしきい値を{estimated_memory_mb}MB以上に設定するか、チャンクサイズを小さくしてください")
+    
+    def _validate_system_compatibility(self, 
+                                      config: KumihanConfig, 
+                                      result: ValidationResult) -> None:
+        """システム環境との整合性검証"""
+        
+        # Python版本检证
+        import sys
+        if sys.version_info < (3, 8):
+            result.add_error("Python 3.8以上が必要です")
+        
+        # 可用的内存检证
+        try:
+            import psutil
+            available_memory_mb = psutil.virtual_memory().available // (1024 * 1024)
+            
+            if config.parallel.memory_critical_threshold_mb > available_memory_mb * 0.8:
+                result.add_warning("メモリクリティカルしきい値がシステムメモリに対して高すぎます")
+                result.add_suggestion(f"利用可能メモリ{available_memory_mb}MBに対してより低い値を設定してください")
+                
+        except ImportError:
+            result.add_suggestion("より正確なメモリ検証のためpsutilのインストールを推奨")
+    
+    def _apply_auto_fixes(self, 
+                         config: KumihanConfig, 
+                         result: ValidationResult) -> KumihanConfig:
+        """自動修正を適用
+        
+        Args:
+            config: 元の設定
+            result: 検証結果
+            
+        Returns:
+            KumihanConfig: 修正された設定
+        """
+        fixed_config = config.copy(deep=True)
+        
+        # ログディレクトリの修正
+        if not fixed_config.logging.log_dir.exists():
+            try:
+                fixed_config.logging.log_dir = Path.home() / ".kumihan" / "logs"
+                result.add_suggestion("ログディレクトリをユーザーホームディレクトリに変更しました")
+            except Exception:
+                pass
+        
+        # メモリしきい値の調整
+        if (fixed_config.parallel.memory_critical_threshold_mb <= 
+            fixed_config.parallel.memory_warning_threshold_mb):
+            fixed_config.parallel.memory_critical_threshold_mb = (
+                fixed_config.parallel.memory_warning_threshold_mb + 50
+            )
+            result.add_suggestion("メモリクリティカルしきい値を警告しきい値より高く調整しました")
+        
+        return fixed_config
+    
+    # ヘルパーメソッド
+    
+    def _is_valid_css_value(self, value: str) -> bool:
+        """CSS値の妥当性チェック"""
+        if not value or not isinstance(value, str):
+            return False
+        
+        # 基本的なCSS値のパターン
+        patterns = [
+            r'^\d+px$',  # ピクセル
+            r'^\d+%$',   # パーセント
+            r'^auto$',   # auto
+            r'^\d+em$',  # em
+            r'^\d+rem$', # rem
+        ]
+        
+        return any(re.match(pattern, value.strip()) for pattern in patterns)
+    
+    def _is_valid_color(self, value: str) -> bool:
+        """色値の妥当性チェック"""
+        if not value or not isinstance(value, str):
+            return False
+        
+        value = value.strip().lower()
+        
+        # HEX色
+        if re.match(r'^#[0-9a-f]{3}$', value) or re.match(r'^#[0-9a-f]{6}$', value):
+            return True
+        
+        # RGB色
+        if re.match(r'^rgb\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\)$', value):
+            return True
+        
+        # 基本的な色名
+        basic_colors = {
+            'white', 'black', 'red', 'green', 'blue', 'yellow', 'cyan', 'magenta',
+            'gray', 'grey', 'transparent'
+        }
+        
+        return value in basic_colors
+    
+    def _is_valid_browser_command(self, command: str) -> bool:
+        """ブラウザコマンドの妥当性チェック"""
+        if not command or not isinstance(command, str):
+            return False
+        
+        # コマンドの最初の部分を取得
+        cmd_parts = command.split()
+        if not cmd_parts:
+            return False
+        
+        executable = cmd_parts[0]
+        
+        # パスが絶対パスの場合
+        if Path(executable).is_absolute():
+            return Path(executable).exists()
+        
+        # PATHから検索
+        import shutil
+        return shutil.which(executable) is not None
+    
+    def _generate_validation_suggestion(self, error: Dict[str, Any]) -> Optional[str]:
+        """Pydantic検証エラーから修正提案を生成
+        
+        Args:
+            error: Pydantic检證エラー情報
+            
+        Returns:
+            Optional[str]: 修正提案
+        """
+        error_type = error.get('type', '')
+        field = error.get('loc', [''])[-1] if error.get('loc') else ''
+        
+        suggestions = {
+            'value_error.number.not_ge': f"{field}にはより大きな値を設定してください",
+            'value_error.number.not_le': f"{field}にはより小さな値を設定してください",
+            'type_error.bool': f"{field}にはtrue/falseを設定してください",
+            'type_error.integer': f"{field}には整数を設定してください",
+            'type_error.float': f"{field}には数値を設定してください",
+            'type_error.str': f"{field}には文字列を設定してください",
+            'value_error.missing': f"{field}は必須項目です",
+        }
+        
+        return suggestions.get(error_type)

--- a/kumihan_formatter/core/unified_config/unified_config_manager.py
+++ b/kumihan_formatter/core/unified_config/unified_config_manager.py
@@ -1,0 +1,455 @@
+"""統一設定管理マネージャー
+
+Issue #771対応: 分散した設定管理を統合し、
+一元的な設定読み込み・管理・ホットリロード機能を提供
+
+統一設定管理の中核クラス
+"""
+
+import os
+import time
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union, Callable
+from datetime import datetime
+
+from ..utilities.logger import get_logger
+from ..error_handling import handle_error_unified
+from .config_models import KumihanConfig, ParallelConfig, LoggingConfig, ErrorConfig, RenderingConfig, UIConfig, ConfigFormat
+from .config_loader import ConfigLoader, ConfigLoadError
+from .config_validator import ConfigValidator, ValidationResult
+
+
+class UnifiedConfigManager:
+    """統一設定管理マネージャー
+    
+    全設定の一元管理を提供:
+    - 設定読み込み (環境変数・ファイル・デフォルト)
+    - 設定検証・自動修正
+    - ホットリロード機能
+    - 既存設定クラスとの互換性
+    """
+    
+    def __init__(self, 
+                 config_file: Optional[Union[str, Path]] = None,
+                 auto_reload: bool = False,
+                 validation_enabled: bool = True):
+        """統一設定マネージャー初期化
+        
+        Args:
+            config_file: 設定ファイルパス
+            auto_reload: ホットリロード有効
+            validation_enabled: 設定検証有効
+        """
+        self.logger = get_logger(__name__)
+        
+        # コンポーネント初期化
+        self.loader = ConfigLoader()
+        self.validator = ConfigValidator() if validation_enabled else None
+        
+        # 設定管理
+        self._config: Optional[KumihanConfig] = None
+        self._config_file_path: Optional[Path] = None
+        self._last_modified: Optional[float] = None
+        self._validation_enabled = validation_enabled
+        
+        # ホットリロード設定
+        self._auto_reload = auto_reload
+        self._reload_thread: Optional[threading.Thread] = None
+        self._reload_callbacks: List[Callable[[KumihanConfig], None]] = []
+        self._shutdown_event = threading.Event()
+        
+        # 初期設定読み込み
+        self._load_initial_config(config_file)
+        
+        # ホットリロード開始
+        if self._auto_reload and self._config_file_path:
+            self._start_auto_reload()
+    
+    def _load_initial_config(self, config_file: Optional[Union[str, Path]]) -> None:
+        """初期設定読み込み
+        
+        Args:
+            config_file: 指定された設定ファイル
+        """
+        try:
+            # 1. 設定ファイルの決定
+            if config_file:
+                self._config_file_path = Path(config_file)
+                if not self._config_file_path.exists():
+                    self.logger.warning(f"指定された設定ファイルが見つかりません: {config_file}")
+                    self._config_file_path = None
+            else:
+                self._config_file_path = self.loader.find_config_file()
+            
+            # 2. 設定データの収集・マージ
+            config_data = self._collect_config_data()
+            
+            # 3. 設定の作成・検証
+            self._config = self._create_and_validate_config(config_data)
+            
+            # 4. ファイル監視情報の更新
+            if self._config_file_path and self._config_file_path.exists():
+                self._last_modified = self._config_file_path.stat().st_mtime
+                self._config.config_file_path = self._config_file_path
+            
+            self._config.last_updated = datetime.now().isoformat()
+            
+            self.logger.info("統一設定管理システム初期化完了")
+            if self._config_file_path:
+                self.logger.info(f"設定ファイル: {self._config_file_path}")
+            
+        except Exception as e:
+            self.logger.error(f"設定初期化エラー: {e}", exc_info=True)
+            
+            # エラー時はデフォルト設定を使用
+            self._config = KumihanConfig()
+            self.logger.info("デフォルト設定を使用します")
+            
+            # 統一エラーハンドリング
+            try:
+                handle_error_unified(
+                    e,
+                    context={"config_file": str(config_file) if config_file else None},
+                    operation="config_initialization",
+                    component_name="UnifiedConfigManager"
+                )
+            except Exception:
+                pass  # エラーハンドリング自体のエラーは無視
+    
+    def _collect_config_data(self) -> Dict[str, Any]:
+        """設定データの収集・マージ
+        
+        優先順位: 環境変数 > 設定ファイル > デフォルト
+        
+        Returns:
+            Dict[str, Any]: マージされた設定データ
+        """
+        configs = []
+        
+        # 1. 設定ファイルからの読み込み
+        if self._config_file_path and self._config_file_path.exists():
+            try:
+                file_config = self.loader.load_from_file(self._config_file_path)
+                configs.append(file_config)
+                self.logger.debug(f"設定ファイル読み込み: {len(file_config)}項目")
+            
+            except ConfigLoadError as e:
+                self.logger.error(f"設定ファイル読み込みエラー: {e}")
+        
+        # 2. 環境変数からの読み込み
+        env_config = self.loader.load_from_environment()
+        if env_config:
+            configs.append(env_config)
+            self.logger.debug(f"環境変数読み込み: {len(env_config)}項目")
+        
+        # 3. 設定のマージ
+        merged_config = self.loader.merge_configs(*configs)
+        
+        return merged_config
+    
+    def _create_and_validate_config(self, config_data: Dict[str, Any]) -> KumihanConfig:
+        """設定の作成・検証
+        
+        Args:
+            config_data: 設定データ
+            
+        Returns:
+            KumihanConfig: 検証済み設定
+        """
+        if self.validator:
+            # 設定検証実行
+            validation_result = self.validator.validate_config(config_data, auto_fix=True)
+            
+            if validation_result.errors:
+                self.logger.error("設定検証エラー:")
+                for error in validation_result.errors:
+                    self.logger.error(f"  - {error}")
+            
+            if validation_result.warnings:
+                self.logger.warning("設定検証警告:")
+                for warning in validation_result.warnings:
+                    self.logger.warning(f"  - {warning}")
+            
+            if validation_result.suggestions:
+                self.logger.info("設定改善提案:")
+                for suggestion in validation_result.suggestions:
+                    self.logger.info(f"  - {suggestion}")
+            
+            # 修正された設定を使用
+            if validation_result.fixed_config:
+                return validation_result.fixed_config
+        
+        # 検証なしまたは検証失敗時は基本作成
+        try:
+            return KumihanConfig(**config_data)
+        except Exception as e:
+            self.logger.error(f"設定作成エラー: {e}")
+            return KumihanConfig()  # デフォルト設定
+    
+    def get_config(self) -> KumihanConfig:
+        """現在の統一設定を取得
+        
+        Returns:
+            KumihanConfig: 現在の設定
+        """
+        if self._config is None:
+            self.logger.warning("設定が初期化されていません、デフォルト設定を返します")
+            return KumihanConfig()
+        
+        return self._config
+    
+    def reload_config(self, force: bool = False) -> bool:
+        """設定の再読み込み
+        
+        Args:
+            force: 強制再読み込み
+            
+        Returns:
+            bool: 再読み込み成功
+        """
+        try:
+            # ファイル更新チェック
+            if not force and self._config_file_path and self._config_file_path.exists():
+                current_mtime = self._config_file_path.stat().st_mtime
+                if self._last_modified and current_mtime <= self._last_modified:
+                    return False  # 更新なし
+            
+            self.logger.info("設定を再読み込みしています...")
+            
+            # 設定データの再収集
+            config_data = self._collect_config_data()
+            
+            # 新しい設定の作成・検証
+            new_config = self._create_and_validate_config(config_data)
+            
+            # 設定の更新
+            old_config = self._config
+            self._config = new_config
+            
+            # ファイル監視情報の更新
+            if self._config_file_path and self._config_file_path.exists():
+                self._last_modified = self._config_file_path.stat().st_mtime
+                self._config.config_file_path = self._config_file_path
+            
+            self._config.last_updated = datetime.now().isoformat()
+            
+            # コールバック実行
+            self._execute_reload_callbacks(self._config)
+            
+            self.logger.info("設定再読み込み完了")
+            return True
+            
+        except Exception as e:
+            self.logger.error(f"設定再読み込みエラー: {e}", exc_info=True)
+            
+            # 統一エラーハンドリング
+            try:
+                handle_error_unified(
+                    e,
+                    context={"config_file": str(self._config_file_path) if self._config_file_path else None},
+                    operation="config_reload",
+                    component_name="UnifiedConfigManager"
+                )
+            except Exception:
+                pass
+            
+            return False
+    
+    def save_config(self, 
+                   config_path: Optional[Union[str, Path]] = None,
+                   format: Optional[ConfigFormat] = None) -> bool:
+        """設定をファイルに保存
+        
+        Args:
+            config_path: 保存先パス (Noneの場合は現在のファイル)
+            format: 保存形式
+            
+        Returns:
+            bool: 保存成功
+        """
+        if self._config is None:
+            self.logger.error("保存する設定がありません")
+            return False
+        
+        try:
+            save_path = Path(config_path) if config_path else self._config_file_path
+            
+            if save_path is None:
+                save_path = Path.home() / ".kumihan" / "kumihan.yaml"
+                self.logger.info(f"保存先が指定されていないため、デフォルトパスを使用: {save_path}")
+            
+            self.loader.save_config(self._config, save_path, format)
+            
+            # 保存したファイルを監視対象に設定
+            if not self._config_file_path:
+                self._config_file_path = save_path
+                if self._auto_reload:
+                    self._start_auto_reload()
+            
+            self.logger.info(f"設定保存完了: {save_path}")
+            return True
+            
+        except Exception as e:
+            self.logger.error(f"設定保存エラー: {e}", exc_info=True)
+            return False
+    
+    def add_reload_callback(self, callback: Callable[[KumihanConfig], None]) -> None:
+        """設定再読み込み時のコールバックを追加
+        
+        Args:
+            callback: コールバック関数
+        """
+        self._reload_callbacks.append(callback)
+        self.logger.debug(f"リロードコールバック追加: {len(self._reload_callbacks)}個")
+    
+    def _execute_reload_callbacks(self, new_config: KumihanConfig) -> None:
+        """リロードコールバックを実行
+        
+        Args:
+            new_config: 新しい設定
+        """
+        for callback in self._reload_callbacks:
+            try:
+                callback(new_config)
+            except Exception as e:
+                self.logger.error(f"リロードコールバック実行エラー: {e}", exc_info=True)
+    
+    def _start_auto_reload(self) -> None:
+        """ホットリロード開始"""
+        if self._reload_thread and self._reload_thread.is_alive():
+            return  # 既に実行中
+        
+        self._shutdown_event.clear()
+        self._reload_thread = threading.Thread(
+            target=self._auto_reload_worker,
+            name="ConfigAutoReload",
+            daemon=True
+        )
+        self._reload_thread.start()
+        
+        self.logger.info("設定ホットリロード開始")
+    
+    def _auto_reload_worker(self) -> None:
+        """ホットリロードワーカー"""
+        while not self._shutdown_event.is_set():
+            try:
+                if self.reload_config():
+                    self.logger.debug("設定ファイル更新検出・再読み込み完了")
+                
+                # 1秒間隔でチェック
+                self._shutdown_event.wait(1.0)
+                
+            except Exception as e:
+                self.logger.error(f"ホットリロードエラー: {e}", exc_info=True)
+                self._shutdown_event.wait(5.0)  # エラー時は5秒待機
+    
+    def shutdown(self) -> None:
+        """統一設定管理システムのシャットダウン"""
+        self.logger.info("統一設定管理システムをシャットダウンしています...")
+        
+        # ホットリロード停止
+        if self._reload_thread and self._reload_thread.is_alive():
+            self._shutdown_event.set()
+            self._reload_thread.join(timeout=5.0)
+        
+        self.logger.info("統一設定管理システムシャットダウン完了")
+    
+    def __del__(self):
+        """デストラクタ"""
+        try:
+            self.shutdown()
+        except Exception:
+            pass  # デストラクタでのエラーは無視
+    
+    # 既存設定クラス互換メソッド
+    
+    def get_parallel_config(self) -> ParallelConfig:
+        """並列処理設定を取得 (ParallelProcessingConfig互換)
+        
+        Returns:
+            ParallelConfig: 並列処理設定
+        """
+        return self.get_config().parallel
+    
+    def get_logging_config(self) -> LoggingConfig:
+        """ログ設定を取得
+        
+        Returns:
+            LoggingConfig: ログ設定
+        """
+        return self.get_config().logging
+    
+    def get_error_config(self) -> ErrorConfig:
+        """エラー処理設定を取得 (ErrorConfigManager互換)
+        
+        Returns:
+            ErrorConfig: エラー処理設定
+        """
+        return self.get_config().error
+    
+    def get_rendering_config(self) -> RenderingConfig:
+        """レンダリング設定を取得 (BaseConfig互換)
+        
+        Returns:
+            RenderingConfig: レンダリング設定
+        """
+        return self.get_config().rendering
+    
+    def get_ui_config(self) -> UIConfig:
+        """UI設定を取得
+        
+        Returns:
+            UIConfig: UI設定
+        """
+        return self.get_config().ui
+
+
+# グローバル統一設定マネージャー
+_global_config_manager: Optional[UnifiedConfigManager] = None
+_config_lock = threading.Lock()
+
+
+def get_unified_config_manager(
+    config_file: Optional[Union[str, Path]] = None,
+    auto_reload: bool = False,
+    force_reload: bool = False
+) -> UnifiedConfigManager:
+    """グローバル統一設定マネージャーを取得
+    
+    Args:
+        config_file: 設定ファイルパス
+        auto_reload: ホットリロード有効
+        force_reload: 強制再作成
+        
+    Returns:
+        UnifiedConfigManager: 統一設定マネージャー
+    """
+    global _global_config_manager
+    
+    with _config_lock:
+        if _global_config_manager is None or force_reload:
+            _global_config_manager = UnifiedConfigManager(
+                config_file=config_file,
+                auto_reload=auto_reload
+            )
+        
+        return _global_config_manager
+
+
+def get_unified_config() -> KumihanConfig:
+    """グローバル統一設定を取得
+    
+    Returns:
+        KumihanConfig: 統一設定
+    """
+    return get_unified_config_manager().get_config()
+
+
+def reload_unified_config() -> bool:
+    """グローバル統一設定を再読み込み
+    
+    Returns:
+        bool: 再読み込み成功
+    """
+    return get_unified_config_manager().reload_config(force=True)


### PR DESCRIPTION
## 概要
Issue #771 に対応し、分散していた設定管理クラスを統合する統一設定管理システムを実装しました。

## 実装内容

### 🏗️ アーキテクチャ改善
- **14個の分散設定クラス**を1つの統一システムに集約
- **Pydanticベース**の型安全な設定モデル実装
- 設定の**一元管理**・**ホットリロード**機能搭載

### ⚡ 主要機能

#### 1. 統一設定管理 (`UnifiedConfigManager`)
- 環境変数・設定ファイル・デフォルト値の優先順位制御
- 自動設定検証・修正機能
- ホットリロード対応（設定ファイル変更を自動検出）

#### 2. 設定モデル (`config_models.py`)
- `ParallelConfig`: 並列処理設定（しきい値、チャンク、メモリ管理）
- `LoggingConfig`: ログ設定（レベル、ローテーション、開発ログ）
- `ErrorConfig`: エラー処理設定（graceful errors、カテゴリ別設定）
- `RenderingConfig`: レンダリング設定（CSS、テーマ、構文ハイライト）
- `UIConfig`: UI設定（プレビュー、プログレス表示、ファイル監視）

#### 3. 設定ローダー (`config_loader.py`)
- **YAML/JSON**形式対応（TOML読込対応）
- 環境変数の体系的サポート（`KUMIHAN_`プレフィックス）
- 設定ファイル自動検出機能
- 設定の深いマージ対応

#### 4. 設定バリデーター (`config_validator.py`)
- 包括的な設定検証（値の妥当性、依存関係、システム環境）
- 自動修正提案機能
- CSS値・色値の検証
- メモリ・CPU環境との整合性チェック

#### 5. 互換アダプター (`config_adapters.py`)
- 既存設定クラスとの**完全互換性**維持
- 段階的移行支援（非推奨警告付き）
- 旧APIの透過的サポート

### 📊 品質保証
- 包括的テストスイート作成（8テストケース）
- **Pydantic v2**対応完了
- 設定ファイルサンプル提供（YAML/JSON）

### 🔧 利用方法

#### 基本的な使用例
```python
from kumihan_formatter.core.unified_config import get_unified_config_manager

# 統一設定マネージャー取得
manager = get_unified_config_manager(
    config_file='kumihan.yaml',
    auto_reload=True  # ホットリロード有効
)

# 各種設定の取得
config = manager.get_config()
parallel_config = config.parallel
logging_config = config.logging
error_config = config.error
```

#### 環境変数サポート
```bash
# 設定は環境変数でオーバーライド可能
export KUMIHAN_DEBUG_MODE=true
export KUMIHAN_PARALLEL__PARALLEL_THRESHOLD_LINES=20000
export KUMIHAN_LOGGING__LOG_LEVEL=DEBUG
export KUMIHAN_ERROR__GRACEFUL_ERRORS=true
```

#### 設定ファイル例（YAML）
```yaml
config_version: "1.0"
environment: "production"
debug_mode: false

parallel:
  parallel_threshold_lines: 10000
  memory_warning_threshold_mb: 150

logging:
  log_level: "INFO"
  log_dir: "~/.kumihan/logs"

error:
  graceful_errors: true
  continue_on_error: true
```

### 🔄 既存コードとの互換性

既存のコードは変更なしで動作します：
```python
# 旧コード（動作継続、非推奨警告表示）
from kumihan_formatter.parser import ParallelProcessingConfig
config = ParallelProcessingConfig()

# 新コード（推奨）
from kumihan_formatter.core.unified_config import get_unified_config_manager
config = get_unified_config_manager().get_parallel_config()
```

### ✅ 受け入れ基準達成状況
- [x] 統一設定管理クラス構築
- [x] 全環境変数の体系的対応
- [x] 設定ファイル対応（YAML/JSON）
- [x] 設定検証の強化
- [x] ホットリロード機能

### 📝 関連Issue
- Closes #771

### 🧪 テスト結果
- 設定モデルテスト: 8/8 ✅
- Pydantic v2互換性: ✅
- 環境変数オーバーライド: ✅

### 📚 ドキュメント
- 設定ファイルサンプル追加（`examples/config/`）
- インラインドキュメント完備
- 移行ガイド機能内蔵

---

**レビュアーへのお願い**
- 既存設定クラスとの互換性を重点的に確認してください
- 設定検証ロジックの妥当性をレビューしてください
- パフォーマンスへの影響を評価してください