### PR TITLE
🔧 Fix type error in unordered_parser.py line 38 - Issue #978

### DIFF
--- a/kumihan_formatter/core/parsing/list/parsers/unordered_parser.py
+++ b/kumihan_formatter/core/parsing/list/parsers/unordered_parser.py
@@ -35,9 +35,9 @@ class UnorderedListParser:
 
     def can_handle(self, line: str, list_type: str) -> bool:
         """指定された行とリストタイプを処理可能か判定"""
-        return list_type in ["unordered", "definition", "checklist"] and self.patterns[
-            list_type
-        ].match(line)
+        return list_type in ["unordered", "definition", "checklist"] and bool(
+            self.patterns[list_type].match(line)
+        )
 
     def handle_unordered_list(self, line: str) -> Node:
         """順序なしリストの処理"""


### PR DESCRIPTION
## Summary
- Fixed `can_handle` method return type error in `unordered_parser.py:38`
- Added `bool()` wrapper to convert `Match[str] | None` to `bool` type
- Resolves mypy type compatibility issue

## Test plan
- [x] Type error修正を確認
- [x] 基本動作テスト実行・確認
- [x] 修正箇所の機能動作検証完了

🤖 Generated with [Claude Code](https://claude.ai/code)