### PR TITLE
🔧 Fix type error in ordered_parser.py line 40 - Issue #979

### DIFF
--- a/kumihan_formatter/core/parsing/list/parsers/ordered_parser.py
+++ b/kumihan_formatter/core/parsing/list/parsers/ordered_parser.py
@@ -37,9 +37,9 @@ class OrderedListParser:
 
     def can_handle(self, line: str, list_type: str) -> bool:
         """指定された行とリストタイプを処理可能か判定"""
-        return list_type in ["ordered", "alpha", "roman"] and self.patterns[
-            list_type
-        ].match(line)
+        return list_type in ["ordered", "alpha", "roman"] and bool(
+            self.patterns[list_type].match(line)
+        )
 
     def handle_ordered_list(self, line: str) -> Node:
         """順序付きリストの処理"""


### PR DESCRIPTION
## Summary
- Fixed `can_handle` method return type error in `ordered_parser.py:40`
- Added `bool()` wrapper to convert `Match[str] | None` to `bool` type
- Resolves mypy type compatibility issue

## Test plan
- [x] Type error修正を確認
- [x] 基本動作テスト実行・確認
- [x] 修正箇所の機能動作検証完了

🤖 Generated with [Claude Code](https://claude.ai/code)