### PR TITLE
🔧 Fix type annotation errors in basic_parser.py - Issue #980

### DIFF
--- a/kumihan_formatter/core/parsing/keyword/parsers/basic_parser.py
+++ b/kumihan_formatter/core/parsing/keyword/parsers/basic_parser.py
@@ -10,7 +10,7 @@ Issue #914: アーキテクチャ最適化 - keyword_parser.py分割
 """
 
 import re
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Union
 
 from ....ast_nodes import (
     Node,
@@ -44,7 +44,7 @@ class BasicKeywordParser:
     def _setup_keyword_registry(self) -> None:
         """キーワードレジストリの設定"""
         # デフォルトキーワード定義
-        self.default_keywords = {
+        self.default_keywords: Dict[str, Dict[str, Any]] = {
             # 基本装飾
             "太字": {"type": "decoration", "html_tag": "strong"},
             "斜体": {"type": "decoration", "html_tag": "em"},
@@ -111,7 +111,7 @@ class BasicKeywordParser:
         Returns:
             解析結果辞書
         """
-        result = {
+        result: Dict[str, Union[str, Dict[str, Any], List[Any], int, bool, None]] = {
             "keyword": "",
             "attributes": {},
             "modifiers": [],


### PR DESCRIPTION
## Summary
- Fixed type annotation errors in `basic_parser.py` line 139
- Added comprehensive type annotations for `result` dictionary and `default_keywords`
- Resolved mypy type compatibility issues for variable assignments

## Changes
- **Line 13**: Added `Union` and `List` to imports
- **Line 47**: Added explicit type annotation for `default_keywords`
- **Line 114**: Added explicit type annotation for `result` dictionary

## Test plan
- [x] Type error修正を確認
- [x] 基本動作テスト実行・確認（29 tests passed）
- [x] 修正箇所の機能動作検証完了

🤖 Generated with [Claude Code](https://claude.ai/code)