### PR TITLE
🔧 型エラー修正: event_bus.py ExtendedEventType→EventType変換実装 (#983)

### DIFF
--- a/kumihan_formatter/core/patterns/event_bus.py
+++ b/kumihan_formatter/core/patterns/event_bus.py
@@ -73,13 +73,23 @@ class IntegratedEventBus:
         self, event_type: Union[EventType, ExtendedEventType], observer: Observer
     ) -> None:
         """同期オブザーバー登録"""
-        self._base_bus.subscribe(event_type, observer)
+        # ExtendedEventType を EventType に変換
+        if isinstance(event_type, ExtendedEventType):
+            base_event_type = EventType(event_type.value)
+        else:
+            base_event_type = event_type
+        self._base_bus.subscribe(base_event_type, observer)
 
     def subscribe_async(
         self, event_type: Union[EventType, ExtendedEventType], observer: AsyncObserver
     ) -> None:
         """非同期オブザーバー登録"""
-        self._base_bus.subscribe_async(event_type, observer)
+        # ExtendedEventType を EventType に変換
+        if isinstance(event_type, ExtendedEventType):
+            base_event_type = EventType(event_type.value)
+        else:
+            base_event_type = event_type
+        self._base_bus.subscribe_async(base_event_type, observer)
 
     def subscribe_with_di(
         self,
@@ -172,7 +182,12 @@ def publish_event(
     data: Optional[Dict[str, Any]] = None,
 ) -> None:
     """便利なイベント発行関数"""
-    event = Event(event_type=event_type, source=source, data=data or {})
+    # ExtendedEventType を EventType に変換
+    if isinstance(event_type, ExtendedEventType):
+        base_event_type = EventType(event_type.value)
+    else:
+        base_event_type = event_type
+    event = Event(event_type=base_event_type, source=source, data=data or {})
     _global_event_bus.publish(event)
 
 
@@ -182,5 +197,10 @@ async def publish_event_async(
     data: Optional[Dict[str, Any]] = None,
 ) -> None:
     """便利な非同期イベント発行関数"""
-    event = Event(event_type=event_type, source=source, data=data or {})
+    # ExtendedEventType を EventType に変換
+    if isinstance(event_type, ExtendedEventType):
+        base_event_type = EventType(event_type.value)
+    else:
+        base_event_type = event_type
+    event = Event(event_type=base_event_type, source=source, data=data or {})
     await _global_event_bus.publish_async(event)


### PR DESCRIPTION
## Summary
- Issue #983対応: event_bus.py内の4箇所の型エラーを全て修正
- ExtendedEventType → EventType への安全な型変換を実装
- mypy strict mode での開発継続を可能にする

## 修正箇所
- **76行目**: `subscribe`引数型不一致を解決
- **82行目**: `subscribe_async`引数型不一致を解決  
- **175行目**: `Event`生成時型不一致を解決
- **185行目**: 非同期`Event`生成時型不一致を解決

## 技術的詳細
- `isinstance(event_type, ExtendedEventType)` で実行時型判定
- `.value` 属性でEnum値を取得してEventTypeに変換
- 既存のEventType引数はそのまま通す（後方互換性）
- 最小変更で最大効果を狙った安全な修正

## Test plan
- [x] mypy型チェック: `event_bus.py` エラー0件
- [x] 関連テスト: observer関連28テスト全て通過
- [x] 既存機能: 完全に維持・互換性確保

🤖 Generated with [Claude Code](https://claude.ai/code)