### PR TITLE
🐛 Issue #997: marker_parser.pyのUnboundLocalError修正

### DIFF
--- a/kumihan_formatter/core/parsing/keyword/marker_parser.py
+++ b/kumihan_formatter/core/parsing/keyword/marker_parser.py
@@ -120,6 +120,7 @@ class MarkerParser:
                             content = parts[1] if len(parts) > 1 else ""
 
                             # ルビ記法の特殊処理
+                            ruby_result = None
                             if keyword == "ルビ":
                                 ruby_result = self._parse_ruby_content(content)
                             if ruby_result:


### PR DESCRIPTION
## 📋 Summary

Issue #997で報告された`test_extremely_long_content`テストの失敗を修正しました。

## 🚨 修正した問題

- **エラー**: `UnboundLocalError: cannot access local variable 'ruby_result' where it is not associated with a value`
- **発生場所**: `marker_parser.py:125`行目
- **原因**: 条件文内で定義される変数が、条件外で参照される

## 🐛 バグの詳細

### 問題のあったコード
```python
# ルビ記法の特殊処理
if keyword == "ルビ":
    ruby_result = self._parse_ruby_content(content)
if ruby_result:  # ← keyword != "ルビ"の場合、ruby_resultが未定義
    all_attributes.update(ruby_result)
```

### 問題の流れ
1. `keyword != "ルビ"`の場合、`ruby_result`変数が定義されない
2. 次の行で`if ruby_result:`が実行される
3. `UnboundLocalError`が発生

## 🔧 修正内容

### 修正後のコード
```python
# ルビ記法の特殊処理
ruby_result = None  # ← 変数を初期化
if keyword == "ルビ":
    ruby_result = self._parse_ruby_content(content)
if ruby_result:     # ← 問題解決
    all_attributes.update(ruby_result)
```

### 修正のポイント
- `ruby_result = None`で変数を事前に初期化
- 条件文に関係なく変数が定義される状態を保証
- ルビ以外のキーワードでも安全に動作

## ✅ 検証結果

### テスト成功
- `test_extremely_long_content`: ✅ 成功
- `test_error_patterns.py`全体: ✅ 18テスト全て通過

### 動作確認
- 長大コンテンツ（"非常に長い内容です。" × 10000）の処理が正常完了
- ルビ記法以外のキーワード処理に影響なし
- パーサー全体の動作が安定

### 処理フロー確認
```python
# 各種キーワードでのテスト
"#太字 長いコンテンツ##"   → ruby_result = None → 正常処理
"#ルビ 本文(ほんぶん)##"   → ruby_result = {...} → 正常処理
"#色 red##"              → ruby_result = None → 正常処理
```

## Test plan

- [x] `test_extremely_long_content`テスト実行・成功確認
- [x] `test_error_patterns.py`全体テスト実行・全通過確認
- [x] ルビ記法の動作確認（既存機能が正常動作）
- [x] 他のキーワード処理の回帰確認

🤖 Generated with [Claude Code](https://claude.ai/code)