### PR TITLE
🧪 Issue #1002: trio依存関係修正・テスト実行時のModuleNotFoundError解決

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,24 @@ import pytest
 
 from kumihan_formatter.core.utilities.logger import get_logger
 
+# trio利用可能性チェック
+try:
+    import trio
+    trio_available = True
+except ImportError:
+    trio_available = False
+
+# anyioバックエンド設定 - trioが利用できない場合はasyncioのみ
+def pytest_configure(config):
+    """Configure pytest for anyio backends"""
+    if hasattr(config.option, 'anyio_backends'):
+        if not trio_available:
+            # trioが利用できない場合はasyncioのみ
+            config.option.anyio_backends = ['asyncio']
+        else:
+            # trioが利用可能な場合は両方
+            config.option.anyio_backends = ['asyncio', 'trio']
+
 
 @pytest.fixture
 def logger():

--- a/tests/unit/async_processing/test_async_coordinator.py
+++ b/tests/unit/async_processing/test_async_coordinator.py
@@ -13,6 +13,25 @@ from unittest.mock import AsyncMock, Mock, patch
 import anyio
 import pytest
 
+# trio利用可能性チェック
+try:
+    import trio
+    trio_available = True
+except ImportError:
+    trio_available = False
+
+# pytestプラグイン設定
+pytest_plugins = ["anyio"]
+
+# trioバックエンドのスキップ設定
+def pytest_generate_tests(metafunc):
+    """Customize test parametrization to skip trio when not available"""
+    if "anyio_backend" in metafunc.fixturenames:
+        if trio_available:
+            metafunc.parametrize("anyio_backend", ["asyncio", "trio"])
+        else:
+            metafunc.parametrize("anyio_backend", ["asyncio"])
+
 from kumihan_formatter.core.async_processing.async_coordinator import (
     AsyncCoordinator,
     AsyncTask,


### PR DESCRIPTION
## Summary
- trio未インストール環境でのtest_async_coordinator.pyテスト失敗を修正
- anyioプラグインのバックエンド設定にtrio利用可能性チェックを追加
- trioが利用できない場合はasyncioのみでテストを実行

## Test plan
- [x] trio未インストール環境でtest_async_coordinator.pyが正常実行
- [x] テスト収集時にtrioパラメータが適切に除外されることを確認
- [x] asyncioバックエンドでのテスト実行が正常動作

🤖 Generated with [Claude Code](https://claude.ai/code)