### PR TITLE
🧪 Issue #1005: pytest実行時の警告メッセージ抑制設定追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,9 +186,8 @@ addopts = [
     "--dist=worksteal"          # 効率的な並列分散
     # Issue #1004: benchmark無効化設定はconftest.pyで動的に適用
 ]
-# xdist追加設定
-xdist_auto = true               # 自動ワーカー数調整
-xdist_min_workers = 2           # 最小ワーカー数
+# Issue #1005: xdist設定項目は未対応のため削除
+# xdist設定は addopts の -n=auto と --dist=worksteal で対応
 markers = [
     "unit: Unit tests",
     "integration: Integration tests",
@@ -214,8 +213,12 @@ markers = [
     "anyio: AnyIO async tests"
 ]
 filterwarnings = [
+    # Issue #1005: pytest実行時の警告メッセージ抑制設定
     "ignore::DeprecationWarning",
-    "ignore::PendingDeprecationWarning"
+    "ignore::PendingDeprecationWarning",
+    "ignore::pytest.PytestConfigWarning",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
+    "ignore::ResourceWarning",
     # pytest-benchmark警告は設定ファイルでは条件付き設定が困難なため、
     # Issue #1004: --benchmark-disableオプションで対応
 ]


### PR DESCRIPTION
## Summary
- pytest実行時の不要な警告メッセージを適切に抑制
- 未対応の xdist 設定項目を削除してPytestConfigWarning解消
- 各種警告フィルター設定を追加してテスト出力をクリーン化

## Test plan
- [x] PytestConfigWarningが表示されなくなる
- [x] テスト出力から警告セクションが消失する
- [x] 重要なエラーの視認性が向上する
- [x] テスト機能に影響を与えない

🤖 Generated with [Claude Code](https://claude.ai/code)