### PR TITLE
🔧 CI修正: test_統合_完全なネストワークフロー テストの修正

### DIFF
--- a/kumihan_formatter/core/parsing/list/parsers/nested_parser.py
+++ b/kumihan_formatter/core/parsing/list/parsers/nested_parser.py
@@ -198,7 +198,11 @@ class NestedListParser:
         max_level = 0
 
         for item in items:
-            level = item.metadata.get("relative_level", 0)
+            # relative_level, nest_level, level の順で確認
+            level = item.metadata.get(
+                "relative_level",
+                item.metadata.get("nest_level", item.metadata.get("level", 0)),
+            )
             level_counts[level] = level_counts.get(level, 0) + 1
             max_level = max(max_level, level)
 


### PR DESCRIPTION
## Summary
- get_nesting_statisticsメソッドのメタデータ参照ロジックを修正
- assert False is True となっていたテスト失敗の根本原因を解決
- CI/CDパイプライン安定化に貢献

## 解決したIssue
- Issue #1037: CI修正: test_統合_完全なネストワークフロー テストの修正

## 変更内容
- `get_nesting_statistics`メソッドでrelative_level, nest_level, level の順でメタデータを確認
- 以前は`relative_level`のみ参照していたため、常に0になっていた問題を修正
- ネスト構造の統計情報が正しく取得できるようになった

## 問題の詳細
テスト内で`assert stats["has_nesting"] is True`が`assert False is True`となって失敗していました。
これは`get_nesting_statistics`メソッドが`relative_level`メタデータのみを参照していたが、
`parse_nested_list`で生成されるノードには`level`や`nest_level`メタデータしか設定されていなかったためです。

## Test plan
- [x] test_統合_完全なネストワークフロー テストの正常実行確認
- [x] 修正により他のテストに影響がないことを確認
- [x] Black フォーマット適用済み

🤖 Generated with [Claude Code](https://claude.ai/code)