### PR TITLE
🔧 CI修正: quality_checker モジュールのインポート警告修正

### DIFF
--- a/tools/automation/__init__.py
+++ b/tools/automation/__init__.py
@@ -8,10 +8,27 @@ Phase 4-2: 自動品質チェック実装
 - PR時自動検証
 """
 
-from .auto_formatter import AutoFormatter
-from .pre_commit_hooks import PreCommitHookManager
-from .quality_checker import QualityChecker
 
-__all__ = ["PreCommitHookManager", "QualityChecker", "AutoFormatter"]
+# sys.modules重複インポートWarning回避のため、遅延インポートを使用
+def get_auto_formatter():
+    """AutoFormatterを取得（遅延インポート）"""
+    from .auto_formatter import AutoFormatter
+
+    return AutoFormatter
+
+
+def get_pre_commit_hook_manager():
+    """PreCommitHookManagerを取得（遅延インポート）"""
+    from .pre_commit_hooks import PreCommitHookManager
+
+    return PreCommitHookManager
+
+
+def get_quality_checker():
+    """QualityCheckerを取得（遅延インポート）"""
+    from .quality_checker import QualityChecker
+
+    return QualityChecker
+
 
 __version__ = "1.0.0"


### PR DESCRIPTION
## Summary
- quality_checkerモジュールのsys.modules重複インポートWarning問題を修正
- Quality Gateワークフローでの正常動作を実現
- モジュールインポートの適切な処理を実装

## 解決したIssue
- Issue #1041: CI修正: quality_checker モジュールのインポート警告修正

## 変更内容
- `tools/automation/__init__.py`で直接インポートを遅延インポートに変更
- `from .quality_checker import QualityChecker`を`get_quality_checker()`関数に変更
- 他のモジュール（AutoFormatter, PreCommitHookManager）も同様に修正

## 問題の詳細
以前は`__init__.py`で以下のような直接インポートを行っていました：
```python
from .quality_checker import QualityChecker
```
これにより、パッケージのインポート時に`RuntimeWarning: 'tools.automation.quality_checker' found in sys.modules after import of package 'tools.automation'`が発生していました。

## 修正後の仕組み
遅延インポート関数を使用することで、モジュールが実際に必要な時にのみロードされます：
```python
def get_quality_checker():
    """QualityCheckerを取得（遅延インポート）"""
    from .quality_checker import QualityChecker
    return QualityChecker
```

## Test plan
- [x] パッケージのインポートでWarningが発生しないことを確認
- [x] QualityChecker の遅延インポート動作確認
- [x] インスタンス作成が正常に行われることを確認
- [x] Black フォーマット適用済み

🤖 Generated with [Claude Code](https://claude.ai/code)