### PR TITLE
⚡ CI最適化: comprehensive_tests のタイムアウト設定見直し

### DIFF
--- a/.github/workflows/optimized_ci.yml
+++ b/.github/workflows/optimized_ci.yml
@@ -128,13 +128,13 @@ jobs:
   # 包括的テスト - PR時のみ実行
   comprehensive_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     needs: [fast_quality, light_tests]
     if: github.event_name == 'pull_request' && needs.fast_quality.result == 'success'
 
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 3
       matrix:
         python-version: [3.12, 3.13]
         test-type: [integration, end_to_end, system]
@@ -156,14 +156,14 @@ jobs:
           comprehensive-${{ runner.os }}-${{ matrix.python-version }}-
 
     - name: Install dependencies
-      timeout-minutes: 8
+      timeout-minutes: 6
       run: |
         python -m pip install --upgrade pip
         pip install -e ".[dev,performance,ai_optimization]"
         pip install pytest-xdist pytest-timeout pytest-sugar --upgrade
 
     - name: Run comprehensive tests with coverage
-      timeout-minutes: 20
+      timeout-minutes: 25
       continue-on-error: ${{ matrix.test-type == 'system' }}
       env:
         PYTEST_XDIST_WORKER_COUNT: auto


### PR DESCRIPTION
## Issue #1048対応

### 🎯 概要
comprehensive_tests ジョブのタイムアウト設定を最適化し、長時間テストの正常完了を確保

### ⚡ 最適化内容

#### 1. ジョブ全体タイムアウトの拡大
```yaml
# 修正前: 25分 → 修正後: 35分
timeout-minutes: 35
```
- systemテスト(20分) + セットアップ時間の安全マージン確保

#### 2. 依存インストールタイムアウトの効率化
```yaml
# 修正前: 8分 → 修正後: 6分  
timeout-minutes: 6
```
- キャッシュ活用により実際は数分で完了するため効率化

#### 3. テスト実行タイムアウトの調整
```yaml
# 修正前: 20分 → 修正後: 25分
timeout-minutes: 25
```
- systemテスト(pytest --timeout=1200)の20分 + 余裕時間確保

#### 4. 並列実行数の最適化
```yaml
# 修正前: 2 → 修正後: 3
max-parallel: 3
```
- Python 3.12/3.13 × 3テスト種類の効率的な並列実行

### 📊 テスト規模に基づく設定
- **Integration tests**: 12ファイル (600秒タイムアウト)
- **End-to-end tests**: 4ファイル (900秒タイムアウト) 
- **System tests**: 4ファイル (1200秒=20分タイムアウト)

### ✅ 期待される効果
- 長時間テストの正常完了確保
- 効率的なリソース活用とCI時間短縮
- タイムアウト発生の防止
- 適切な時間配分による安定性向上

### 🧪 検証
- YAML構文チェック: ✅ 正常
- pre-commitフック: ✅ 通過
- 数値妥当性: ✅ systemテスト20分+その他≤25分≤35分

🤖 Generated with [Claude Code](https://claude.ai/code)