### PR TITLE
🔧 Issue #1084: HTMLタグバリデーション修正

### DIFF
--- a/kumihan_formatter/core/parsing/keyword/definitions.py
+++ b/kumihan_formatter/core/parsing/keyword/definitions.py
@@ -276,20 +276,30 @@ class KeywordDefinitions:
         # 有効なHTMLタグのチェック
         valid_tags = {
             "strong",
+            "b",          # 太字 (代替表記)
             "em",
+            "i",          # イタリック (代替表記)
             "div",
+            "span",
+            "p",
             "h1",
             "h2",
             "h3",
             "h4",
             "h5",
-            "details",
-            "u",
+            "h6",
+            "blockquote", # 引用
+            "pre",        # コードブロック
             "code",
+            "details",
+            "summary",    # details要素の子要素
+            "u",
             "del",
+            "ins",        # 挿入テキスト
+            "mark",       # ハイライト
             "ruby",
-            "span",
-            "p",
+            "rt",         # ruby text
+            "rp",         # ruby parentheses
         }
 
         if tag not in valid_tags:


### PR DESCRIPTION
## 概要
Issue #1084対応: HTMLタグバリデーションで`b`、`pre`タグが無効扱いされる問題を修正

## 🎯 解決した問題
- `test_definition_override_mechanism`: `b`タグが無効扱い
- `test_html_tag_validation`: `pre`タグが無効扱い
- HTMLバリデーション機能の過度な制限

## 🔧 修正内容

### 有効HTMLタグリストの拡張
```python
# 追加されたタグ
valid_tags = {
    "b",          # 太字 (代替表記)
    "i",          # イタリック (代替表記)
    "blockquote", # 引用
    "pre",        # コードブロック
    "h6",         # 見出し6
    "summary",    # details要素の子要素
    "ins",        # 挿入テキスト
    "mark",       # ハイライト
    "rt",         # ruby text
    "rp",         # ruby parentheses
    # ... その他既存タグ
}
```

### 論理的整合性の確保
- デフォルトキーワードで使用されているタグ (`pre`, `blockquote`) を許可リストに追加
- HTML5標準で一般的なタグを網羅的に追加
- セマンティックHTML対応の強化

## 📊 テスト結果
- ✅ `test_definition_override_mechanism`: PASS
- ✅ `test_html_tag_validation`: PASS
- ✅ `test_definitions_comprehensive.py` 全29テスト: PASS

## 🚀 期待効果
- HTMLタグバリデーションエラーの解消
- より柔軟なカスタムキーワード定義の実現
- HTML5標準への準拠向上

## 📝 影響範囲
- `kumihan_formatter/core/parsing/keyword/definitions.py`: バリデーション関数のみ
- 既存機能への影響なし（制限緩和のみ）

Closes #1084

🤖 Generated with [Claude Code](https://claude.ai/code)