### PR TITLE
🔧 Issue #1085: CSSスタイル解析テスト修正

### DIFF
--- a/tests/unit/parsing/keyword/test_attribute_parser_comprehensive.py
+++ b/tests/unit/parsing/keyword/test_attribute_parser_comprehensive.py
@@ -223,17 +223,17 @@ class TestAttributeParserCSS:
         # 基本スタイル
         content = 'style="color: red;"'
         attributes = self.parser.parse_attributes_from_content(content)
-        assert attributes["style"] == "color:"  # パターンマッチング結果
+        assert attributes["style"] == "color: red;"  # 完全なスタイル値
 
         # 複数プロパティ
         content = 'style="color: red; background: blue; margin: 10px;"'
         attributes = self.parser.parse_attributes_from_content(content)
-        assert "style" in attributes
+        assert attributes["style"] == "color: red; background: blue; margin: 10px;"
 
         # 複雑な値
         content = 'style="background: linear-gradient(45deg, red, blue);"'
         attributes = self.parser.parse_attributes_from_content(content)
-        assert "style" in attributes
+        assert attributes["style"] == "background: linear-gradient(45deg, red, blue);"
 
     def test_css_selector_compatibility(self):
         """CSSセレクター互換性テスト"""


### PR DESCRIPTION
## 概要
Issue #1085対応: CSSスタイル解析テストの期待値不整合を修正

## 🎯 解決した問題
- `test_inline_style_property_parsing`: 期待値 `"color:"` vs 実際値 `"color: red;"`
- AttributeParser実装は正常動作していたが、テストの期待値が不適切

## 🔧 修正内容

### テスト期待値の修正
```python
# 修正前
assert attributes["style"] == "color:"  # パターンマッチング結果

# 修正後  
assert attributes["style"] == "color: red;"  # 完全なスタイル値
```

### 包括的なテスト修正
- **基本スタイル**: `"color: red;"` の完全な値を期待
- **複数プロパティ**: `"color: red; background: blue; margin: 10px;"` を期待
- **複雑な値**: `"background: linear-gradient(45deg, red, blue);"` を期待

## 📊 根本原因分析
- AttributeParser.parse_attributes_from_content() は正しく動作
- テストコメント「パターンマッチング結果」が誤解を招いていた
- 実装とテストの期待値に齟齬があった

## ✅ テスト結果
- ✅ `test_inline_style_property_parsing`: PASS
- ✅ `test_attribute_parser_comprehensive.py` 全28テスト: PASS
- ✅ CSSスタイル解析機能の正常動作確認

## 🚀 期待効果
- CI環境でのテスト失敗解消
- CSSスタイル解析機能の信頼性向上
- テストカバレッジの適切性確保

## 📝 影響範囲
- テストファイルのみ（実装コードに変更なし）
- 期待値の明確化によるテスト品質向上

Closes #1085

🤖 Generated with [Claude Code](https://claude.ai/code)