### PR TITLE
🔧 Issue #1089: 最大レベル制限エラーメッセージ修正

### DIFF
--- a/tests/unit/parsing/list/parsers/test_nested_parser.py
+++ b/tests/unit/parsing/list/parsers/test_nested_parser.py
@@ -236,7 +236,27 @@ class TestNestedListParser:
 
         # Then: エラーが検出されることを検証
         assert len(errors) > 0
-        assert "制限を超えています" in errors[0]
+        assert "ネストレベルが急激に変化" in errors[0]
+
+    def test_異常系_最大レベル制限超過_段階的(self):
+        """異常系: 最大レベル制限を超える構造（段階的）"""
+        # Given: 段階的に最大レベルを超える深いネスト
+        items = [
+            create_node("list_item", content="項目1", metadata={"relative_level": 0}),
+            create_node("list_item", content="項目2", metadata={"relative_level": 1}),
+            create_node("list_item", content="項目3", metadata={"relative_level": 2}),
+            create_node("list_item", content="項目4", metadata={"relative_level": 3}),
+            create_node(
+                "list_item", content="深すぎる", metadata={"relative_level": 4}
+            ),  # max_nest_level=3を超える
+        ]
+
+        # When: ネスト構造検証
+        errors = self.parser.validate_nesting_structure(items)
+
+        # Then: エラーが検出されることを検証
+        assert len(errors) > 0
+        assert "制限を超えています" in errors[-1]  # 最後のエラーメッセージをチェック
 
     def test_異常系_空のノードリスト処理(self):
         """異常系: 空のノードリストの処理"""
@@ -335,7 +355,7 @@ class TestNestedListParser:
         # CI環境での実行時間を考慮して削減
         from tests.conftest import get_test_data_size
         node_count = get_test_data_size(1000, 100)
-        
+
         # Given: 大量のノード
         large_items = []
         for i in range(node_count):


### PR DESCRIPTION
## Summary
- test_異常系_最大レベル制限超過のテスト期待値を実動作に合わせて修正
- 新規テストケースtest_異常系_最大レベル制限超過_段階的を追加して制限チェックを分離
- エラーメッセージ「制限を超えています」と「急激に変化」の文言不整合を解決

## 変更内容
Issue #1089で報告されたCIエラーの根本原因は、エラーメッセージの期待値とパーサーの実際の動作に不整合があることでした。

### 問題の詳細
- テストは「制限を超えています」メッセージを期待
- 実際には「ネストレベルが急激に変化」エラーが先に発生
- `validate_nesting_structure`メソッドで急激変化チェックが先に実行されるため

### 修正内容
1. **test_異常系_最大レベル制限超過**: 期待値を実際の動作に合わせて「ネストレベルが急激に変化」に修正
2. **test_異常系_最大レベル制限超過_段階的**: 新規テストケースで段階的なレベル上昇により純粋な「制限を超えています」エラーをテスト

## Test plan
- [x] 修正したテストケースが通ることを確認
- [x] 新しいテストケースが通ることを確認
- [x] 既存のネストパーサー関連テストが全て通ることを確認

## 関連Issue
Closes #1089

🤖 Generated with [Claude Code](https://claude.ai/code)