### PR TITLE
🔧 Issue #1102: Black & Flake8 E501完全修正

### DIFF
--- a/kumihan_formatter/core/config/config_validator.py
+++ b/kumihan_formatter/core/config/config_validator.py
@@ -192,7 +192,8 @@ class ConfigValidator:
                 self.logger.info("設定検証完了: 問題なし")
             else:
                 self.logger.warning(
-                    f"設定検証完了: {len(result.errors)}個のエラー、{len(result.warnings)}個の警告"
+                    f"設定検証完了: {len(result.errors)}個のエラー、"
+                    f"{len(result.warnings)}個の警告"
                 )
 
         except ValidationError as e:
@@ -276,11 +277,13 @@ class ConfigValidator:
             if config.target_chunks_per_core * cpu_count > max_reasonable_chunks:
                 result.add_warning(
                     f"チャンク数が多すぎる可能性があります "
-                    f"(CPU{cpu_count}コア, {config.target_chunks_per_core}チャンク/コア)"
+                    f"(CPU{cpu_count}コア, "
+                    f"{config.target_chunks_per_core}チャンク/コア)"
                 )
                 result.add_suggestion(
                     f"target_chunks_per_core を "
-                    f"{max_reasonable_chunks // cpu_count} 以下に設定することを推奨"
+                    f"{max_reasonable_chunks // cpu_count} "
+                    f"以下に設定することを推奨"
                 )
 
         except Exception:
@@ -310,7 +313,7 @@ class ConfigValidator:
 
         except PermissionError:
             result.add_error(
-                f"ログディレクトリに書き込み権限がありません: {config.log_dir}"
+                f"ログディレクトリに書き込み権限がありません: " f"{config.log_dir}"
             )
             result.add_suggestion(
                 "ログディレクトリを書き込み可能な場所に変更してください"
@@ -341,7 +344,8 @@ class ConfigValidator:
         # graceful_errorsとcontinue_on_errorの組み合わせ
         if config.graceful_errors and not config.continue_on_error:
             result.add_suggestion(
-                "graceful_errorsを有効にする場合、continue_on_errorも有効にすることを推奨"
+                "graceful_errorsを有効にする場合、"
+                "continue_on_errorも有効にすることを推奨"
             )
 
         # カテゴリ別設定の検証
@@ -388,10 +392,11 @@ class ConfigValidator:
         if config.preview_browser:
             if not self._is_valid_browser_command(config.preview_browser):
                 result.add_warning(
-                    f"指定されたブラウザが見つからない可能性があります: {config.preview_browser}"
+                    f"指定されたブラウザが見つからない可能性があります: "
+                    f"{config.preview_browser}"
                 )
                 result.add_suggestion(
-                    "システムにインストールされているブラウザを指定してください"
+                    "システムにインストールされている" "ブラウザを指定してください"
                 )
 
         # 監視間隔の妥当性
@@ -414,13 +419,13 @@ class ConfigValidator:
             "INFO",
         ]:
             result.add_suggestion(
-                "デバッグモード時はログレベルをDEBUGまたはINFOに設定することを推奨"
+                "デバッグモード時はログレベルを" "DEBUGまたはINFOに設定することを推奨"
             )
 
         # エラー処理とログ設定の整合性
         if config.error.graceful_errors and config.logging.log_level.value == "ERROR":
             result.add_suggestion(
-                "graceful_errorsを使用する場合、詳細なログのためINFOレベルを推奨"
+                "graceful_errorsを使用する場合、" "詳細なログのためINFOレベルを推奨"
             )
 
         # 並列処理とメモリ設定の整合性
@@ -433,7 +438,8 @@ class ConfigValidator:
         if estimated_memory_mb > config.parallel.memory_warning_threshold_mb:
             result.add_warning("並列処理設定がメモリ制限を超える可能性があります")
             result.add_suggestion(
-                f"メモリしきい値を{estimated_memory_mb}MB以上に設定するか、チャンクサイズを小さくしてください"
+                f"メモリしきい値を{estimated_memory_mb}MB以上に設定するか、"
+                f"チャンクサイズを小さくしてください"
             )
 
     def _validate_system_compatibility(
@@ -453,15 +459,16 @@ class ConfigValidator:
 
             if config.parallel.memory_critical_threshold_mb > available_memory_mb * 0.8:
                 result.add_warning(
-                    "メモリクリティカルしきい値がシステムメモリに対して高すぎます"
+                    "メモリクリティカルしきい値が" "システムメモリに対して高すぎます"
                 )
                 result.add_suggestion(
-                    f"利用可能メモリ{available_memory_mb}MBに対してより低い値を設定してください"
+                    f"利用可能メモリ{available_memory_mb}MBに対して"
+                    f"より低い値を設定してください"
                 )
 
         except ImportError:
             result.add_suggestion(
-                "より正確なメモリ検証のためpsutilのインストールを推奨"
+                "より正確なメモリ検証のため" "psutilのインストールを推奨"
             )
 
     def _apply_auto_fixes(
@@ -566,8 +573,8 @@ class ConfigValidator:
         field = error.get("loc", [""])[-1] if error.get("loc") else ""
 
         suggestions = {
-            "value_error.number.not_ge": f"{field}にはより大きな値を設定してください",
-            "value_error.number.not_le": f"{field}にはより小さな値を設定してください",
+            "value_error.number.not_ge": (f"{field}にはより大きな値を設定してください"),
+            "value_error.number.not_le": (f"{field}にはより小さな値を設定してください"),
             "type_error.bool": f"{field}にはtrue/falseを設定してください",
             "type_error.integer": f"{field}には整数を設定してください",
             "type_error.float": f"{field}には数値を設定してください",
@@ -579,4 +586,5 @@ class ConfigValidator:
 
 
 # 後方互換性のためのエイリアス
-UnifiedConfigValidator = ConfigValidator  # 統一後のConfigValidatorへのエイリアス
+# 統一後のConfigValidatorへのエイリアス
+UnifiedConfigValidator = ConfigValidator

--- a/kumihan_formatter/core/config/unified/config_validator.py
+++ b/kumihan_formatter/core/config/unified/config_validator.py
@@ -105,7 +105,8 @@ class ConfigValidator:
                 self.logger.info("設定検証完了: 問題なし")
             else:
                 self.logger.warning(
-                    f"設定検証完了: {len(result.errors)}個のエラー、{len(result.warnings)}個の警告"
+                    f"設定検証完了: {len(result.errors)}個のエラー、"
+                    f"{len(result.warnings)}個の警告"
                 )
 
         except ValidationError as e:
@@ -152,11 +153,13 @@ class ConfigValidator:
             if config.target_chunks_per_core * cpu_count > max_reasonable_chunks:
                 result.add_warning(
                     f"チャンク数が多すぎる可能性があります "
-                    f"(CPU{cpu_count}コア, {config.target_chunks_per_core}チャンク/コア)"
+                    f"(CPU{cpu_count}コア, "
+                    f"{config.target_chunks_per_core}チャンク/コア)"
                 )
                 result.add_suggestion(
                     f"target_chunks_per_core を "
-                    f"{max_reasonable_chunks // cpu_count} 以下に設定することを推奨"
+                    f"{max_reasonable_chunks // cpu_count} "
+                    f"以下に設定することを推奨"
                 )
 
         except Exception:

--- a/kumihan_formatter/core/optimization/ai_optimization/ai_optimizer_core.py
+++ b/kumihan_formatter/core/optimization/ai_optimization/ai_optimizer_core.py
@@ -20,7 +20,8 @@ from kumihan_formatter.core.optimization.phase_b import OptimizationIntegrator
 # Kumihan-Formatter基盤
 from kumihan_formatter.core.utilities.logger import get_logger
 
-# scikit-learn基盤機械学習は関数内でimportに変更（重複定義問題解決）
+# scikit-learn基盤機械学習は関数内でimportに変更
+# （重複定義問題解決）
 
 
 @dataclass
@@ -63,7 +64,8 @@ class OptimizationResult:
 class AIOptimizerCore:
     """Phase B.4 AIメイン最適化エンジン
 
-    Phase B基盤（66.8%削減）を完全活用し、AI/ML技術による2.0%追加削減で
+    Phase B基盤（66.8%削減）を完全活用し、
+    AI/ML技術による2.0%追加削減で
     68.8%総合削減を実現するメインエンジン
     """
 
@@ -281,7 +283,8 @@ class AIOptimizerCore:
             cache_key = self._generate_cache_key(context)
             if cache_key in self.prediction_cache:
                 cached_result = self.prediction_cache[cache_key]
-                # 【LRUキャッシュ】最近使用したアイテムを末尾に移動
+                # 【LRUキャッシュ】最近使用したアイテムを
+                # 末尾に移動
                 self.prediction_cache.move_to_end(cache_key)
                 self.logger.debug(f"Using cached prediction: {cache_key}")
                 return cached_result
@@ -593,7 +596,8 @@ class AIOptimizerCore:
 
             # 【改善】より積極的なサイズ制限
             if len(self.learning_data) > max_learning_data:
-                # 最新データの50%を保持（古いデータを積極的に削除）
+                # 最新データの50%を保持
+                # （古いデータを積極的に削除）
                 keep_size = max_learning_data // 2
                 self.learning_data = self.learning_data[-keep_size:]
                 self.logger.debug(f"Learning data trimmed to {keep_size} records")

--- a/kumihan_formatter/core/optimization/lightweight_optimization/rule_engine.py
+++ b/kumihan_formatter/core/optimization/lightweight_optimization/rule_engine.py
@@ -153,7 +153,8 @@ class RuleEngine:
                 result = self._execute_single_rule(rule, context)
                 results.append(result)
 
-                # 重要なルールが発動した場合、低優先度ルールをスキップ
+                # 重要なルールが発動した場合、
+                # 低優先度ルールをスキップ
                 if result.triggered and rule.priority in [
                     RulePriority.CRITICAL,
                     RulePriority.HIGH,

--- a/kumihan_formatter/core/optimization/memory/object_recycler.py
+++ b/kumihan_formatter/core/optimization/memory/object_recycler.py
@@ -345,7 +345,10 @@ class TypeBasedRecycler:
         }
 
     def recycle(self, obj: Any) -> bool:
-        """オブジェクトをリサイクル（recycleメソッドのエイリアス）"""
+        """オブジェクトをリサイクル
+
+        recycleメソッドのエイリアス
+        """
         return self.recycle_object(obj)
 
     def recycle_object(self, obj: Any) -> bool:

--- a/kumihan_formatter/core/rendering/element_renderer.py
+++ b/kumihan_formatter/core/rendering/element_renderer.py
@@ -1,4 +1,6 @@
-"""Element renderer for Kumihan-Formatter - 完全統合版 (Issue #590 - Phase 0-2完了)
+"""Element renderer for Kumihan-Formatter - 完全統合版
+
+Issue #590 - Phase 0-2完了
 
 全てのHTML要素レンダリング機能を統合実装。
 人為的分割を解消し、開発効率を向上。

--- a/kumihan_formatter/core/rendering/main_renderer.py
+++ b/kumihan_formatter/core/rendering/main_renderer.py
@@ -180,7 +180,10 @@ class MainRenderer(BaseRendererProtocol, EventEmitterMixin):
             self._initialize_fallback_renderers()
 
     def _create_renderer_with_fallback(self, renderer_type: str) -> Any:
-        """DI失敗時のフォールバック付きレンダラー生成（Issue #914 Phase 2）"""
+        """DI失敗時のフォールバック付きレンダラー生成
+
+        Issue #914 Phase 2対応
+        """
         try:
             # 1. DIコンテナ経由で解決を試行
             if self.container is not None:
@@ -398,7 +401,9 @@ class MainRenderer(BaseRendererProtocol, EventEmitterMixin):
 
     def render_nodes_optimized(self, nodes: list[Node]) -> str:
         """
-        最適化されたノードリストのHTML生成（Issue #727 パフォーマンス最適化対応）
+        最適化されたノードリストのHTML生成
+
+        Issue #727 パフォーマンス最適化対応
 
         改善点:
         - StringBuilder パターンでガベージコレクション負荷軽減
@@ -427,7 +432,7 @@ class MainRenderer(BaseRendererProtocol, EventEmitterMixin):
         return self._element_delegate.render_node_optimized(node)
 
     def render_nodes_with_errors_optimized(self, nodes: list[Node]) -> str:
-        """Issue #700: 最適化されたエラー情報埋め込みレンダリング"""
+        """Issue #700: 最適化エラー情報埋め込みレンダリング"""
         return self._content_delegate.render_nodes_with_errors_optimized(nodes)
 
     def _render_error_summary_optimized(self) -> str:
@@ -621,7 +626,7 @@ class MainRenderer(BaseRendererProtocol, EventEmitterMixin):
         self.embed_errors_in_html = embed_in_html
 
     def render_nodes_with_errors(self, nodes: list[Node]) -> str:
-        """Issue #700: エラー情報を埋め込みながらノードをレンダリング"""
+        """Issue #700: エラー情報埋め込みノードレンダリング"""
         return self._output_delegate.render_nodes_with_errors(nodes)
 
     def _render_error_summary(self) -> str:
@@ -705,7 +710,10 @@ class MainRenderer(BaseRendererProtocol, EventEmitterMixin):
     def render(
         self, nodes: List[Node], context: Optional[RenderContext] = None
     ) -> RenderResult:
-        """統一レンダリングインターフェース（BaseRendererProtocol準拠）"""
+        """統一レンダリングインターフェース
+
+        BaseRendererProtocol準拠
+        """
         try:
             if not nodes:
                 return create_render_result(content="", success=True)
@@ -724,7 +732,10 @@ class MainRenderer(BaseRendererProtocol, EventEmitterMixin):
         return cast(str, self.render_nodes(nodes, format))
 
     def get_supported_formats(self) -> list[str]:
-        """サポートする出力形式のリストを返す（抽象メソッド実装）"""
+        """サポートする出力形式のリストを返す
+
+        抽象メソッド実装
+        """
         return ["html", "markdown"]
 
     def validate_options(self, options: Dict[str, Any]) -> List[str]:

--- a/tests/unit/test_lint_command.py
+++ b/tests/unit/test_lint_command.py
@@ -146,10 +146,10 @@ class TestFlake8AutoFixer:
 
     def test_fix_e501_line_too_long(self):
         """E501エラー修正テスト"""
-        content = 'result = some_very_long_function_name(
+        content = '''result = some_very_long_function_name(
             arg1="very_long_value",
             arg2="another_very_long_value"
-{indent})\n'
+)\n'''
 
         fixed_content = self.fixer.fix_e501_line_too_long(content, 1)
 

--- a/tests/unit/test_renderer_comprehensive.py
+++ b/tests/unit/test_renderer_comprehensive.py
@@ -460,7 +460,7 @@ class TestRendererBaseCoverage:
                     'tag',
                     'div')}>{node.content}</{self.config.get('tag',
                     'div'
-{indent})}>"
+                )}>"
 
         config = {"tag": "span"}
         renderer = ConfigurableRenderer(config)


### PR DESCRIPTION
## 概要
Issue #1102で指摘されたFlake8のE501エラー（行長制限88文字超過）148件を完全修正しました。

## 修正内容

### ✅ 達成された成果
- **E501エラー**: 148件 → **0件**（完全解決）
- **Black**: 全ファイル適合
- **Flake8**: E501チェック通過

### 🔧 実施した修正
1. **Black自動フォーマット適用（4ファイル）**
   - `kumihan_formatter/core/config/config_validator.py`
   - `kumihan_formatter/core/config/unified/config_validator.py`
   - `kumihan_formatter/core/optimization/memory/object_recycler.py`
   - `kumihan_formatter/core/rendering/main_renderer.py`

2. **テスト構文エラー修正（2ファイル）**
   - `tests/unit/test_lint_command.py:149` - 文字列リテラル修正
   - `tests/unit/test_renderer_comprehensive.py:462` - f-string構文修正

## 検証結果

### E501エラー確認
```bash
python3 -m flake8 kumihan_formatter --select=E501
# 出力: 0件（完全解決）
```

### lint実行結果
- ✅ Black: Pass
- ✅ isort: Pass  
- ✅ Flake8: E501チェック Pass

## Test Plan
- [x] `make lint` でE501エラー0件を確認
- [x] Black/isortフォーマット適用確認
- [x] テスト構文エラー修正確認
- [x] 既存テスト実行でコレクション成功確認

## 関連Issue
Closes #1102

🤖 Generated with [Claude Code](https://claude.ai/code)