### PR TITLE
🔧 gitignore強化: Claude個人設定ファイル除外設定追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,12 @@ venv*/
 # .claude/ already covered in external tools section
 .mcp.json*
 
+# Claude個人設定ファイル（個人の開発環境設定のため除外）
+.claude*.yml
+.claude*.yaml
+.claude*.json
+.cleanup.yml
+
 # AI collaboration関連の動的生成ファイル（旧postbox）
 ai_collaboration/todo/*.json
 ai_collaboration/monitoring/session_*.json


### PR DESCRIPTION
## Summary
- Claude個人設定ファイル（.claude*.yml, .claude*.yaml, .claude*.json）をgitignoreに追加
- .cleanup.ymlを除外設定に追加（個人の開発環境設定のため）
- セキュリティ強化: 個人設定の誤アップロード防止

## 変更内容
- `.claude*.yml`, `.claude*.yaml`, `.claude*.json`パターンを追加
- `.cleanup.yml`を除外対象に追加
- 個人情報は含まれていないことを確認済み

## 理由
これらのファイルは個人の開発環境固有の設定ファイルであり、他の開発者には不要なため、リポジトリから除外することで管理を簡素化します。

🤖 Generated with [Claude Code](https://claude.ai/code)