### PR TITLE
🔧 Issue #1138: parser_instanceフィクスチャ欠如によるテスト失敗修正

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,3 +89,10 @@ def output_file_path(temp_dir: Path) -> Path:
     return temp_dir / "test_output.html"
 
 
+@pytest.fixture
+def parser_instance():
+    """Parserインスタンス提供（Issue #1138対応）"""
+    from kumihan_formatter.parser import Parser
+    return Parser()
+
+


### PR DESCRIPTION
## 🎯 Issue概要
`parser_instance` フィクスチャが見つからずテスト失敗していた問題を修正

**Issue**: #1138
**Priority**: バグ・簡単

## 📋 修正内容
- `tests/conftest.py` に `parser_instance` フィクスチャを追加
- `from kumihan_formatter.parser import Parser` でParserクラスをインポート
- 基本的なParserインスタンスを提供する簡潔な実装

## ✅ 受け入れ基準達成確認
- [x] **parser_instanceフィクスチャをconftest.pyに定義**
- [x] **TestParserPerformanceクラスのテストが正常実行可能**（全15テスト通過）  
- [x] **他のテストに影響しないことを確認**（全テスト正常動作）

## 🧪 テスト結果
```bash
pytest tests/integration/test_parser.py -v --no-cov
======================== 15 passed, 27 warnings in 0.09s ========================
```

## 📄 変更ファイル
- `tests/conftest.py` - parser_instanceフィクスチャ追加

🤖 Generated with [Claude Code](https://claude.ai/code)