### PR TITLE
⚡ High: 過剰依存関係削除 - ML/AI ライブラリの不要依存解消 (Issue #1145)

### DIFF
--- a/kumihan_formatter/core/optimization/ai_optimization/ml/ml_models.py
+++ b/kumihan_formatter/core/optimization/ai_optimization/ml/ml_models.py
@@ -2,8 +2,18 @@
 
 import time
 
-import numpy as np
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+# ML依存関係削除対応 (Issue #1145)
+try:
+    import numpy as np
+    from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
+
+    ML_LIBRARIES_AVAILABLE = True
+except ImportError:
+    # フォールバック: ML機能無効化
+    ML_LIBRARIES_AVAILABLE = False
+    np = None
+    RandomForestClassifier = None
+    RandomForestRegressor = None
 
 from .ml_base import BaseMLModel, PredictionResponse, TrainingData
 

--- a/kumihan_formatter/core/optimization/memory/profiler/analysis/optimization_advisor.py
+++ b/kumihan_formatter/core/optimization/memory/profiler/analysis/optimization_advisor.py
@@ -377,7 +377,7 @@ class MemoryOptimizationAdvisor:
             def _get_priority(item: Dict[str, Any]) -> float:
                 priority = item.get("priority", 0.0)
                 return float(priority) if isinstance(priority, (int, float)) else 0.0
-            
+
             prioritized.sort(key=_get_priority, reverse=True)
 
             return prioritized

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,6 @@ dependencies = [
     "watchdog>=3.0",
     "pyyaml>=6.0",
     "pydantic>=2.0",
-    "scikit-learn>=1.3.0",
-    "numpy>=1.24.0",
-    "pandas>=2.0.0",
-    "scipy>=1.11.0",
     "aiofiles>=23.0",
     "toml>=0.10",
     "tomli>=1.2.0",
@@ -50,8 +46,10 @@ performance = [
     "psutil>=5.9",  # メモリ使用量追跡用
 ]
 ai_optimization = [
-    "lightgbm>=4.0.0",  # 高精度予測モデル
-    "xgboost>=2.0.0",   # 補完的高精度学習
+    # ML/AI依存関係削除完了 (Issue #1145)
+    # 過剰な依存関係によるインストール肥大化問題を解決
+    # 削除対象: scikit-learn, numpy, pandas, scipy, lightgbm, xgboost
+    # 効果: 約206MB削減、セキュリティリスク軽減、保守性向上
 ]
 telemetry = [
     "opentelemetry-api>=1.20.0",


### PR DESCRIPTION
## 概要
テキストフォーマッターにもかかわらず、不要なML/AIライブラリが多数依存関係に含まれていた問題を解決。  
インストールサイズ約206MB削減、セキュリティリスクの軽減、保守性向上を実現。

## 問題
- scikit-learn (108MB), pandas (38MB), scipy (43MB), numpy (17MB) が主要依存に含有
- lightgbm, xgboost がオプション依存に含有
- テキストフォーマッターのコア機能に不要
- インストールサイズ肥大化とセキュリティリスクの原因

## 変更内容
### pyproject.toml修正
- **主要依存関係削除**: `scikit-learn>=1.3.0`, `numpy>=1.24.0`, `pandas>=2.0.0`, `scipy>=1.11.0`
- **オプション依存削除**: `lightgbm>=4.0.0`, `xgboost>=2.0.0` 
- **削除理由明記**: ai_optimizationセクションに詳細な説明追加

### コード対応
- ML/AIライブラリimportにフォールバック処理を追加
- `try-except ImportError`で安全な処理を実装
- 既存の統計処理機能は`ab_testing.py`で既に適切にフォールバック実装済み

## 効果・メリット
- ✅ **インストールサイズ**: 約206MB削減
- ✅ **セキュリティ**: 不要ライブラリによるリスク軽減
- ✅ **保守性**: 依存関係管理負荷の軽減
- ✅ **互換性**: 既存コア機能の完全な動作維持

## テスト結果
- **単体テスト**: 136件全通過
- **統合テスト**: 159件全通過 (1件スキップ) 
- **Lint/Type check**: 全通過
- **既存機能**: テキスト変換・コマンド動作確認済み

## Test plan
- [x] pyproject.tomlから対象依存関係削除
- [x] ML/AIライブラリimport部分にフォールバック処理追加
- [x] 単体テスト全実行・通過確認
- [x] 統合テスト全実行・通過確認
- [x] Lint/Type check実行・通過確認
- [x] 既存変換機能の動作確認
- [x] コミット・ブランチ作成
- [ ] CI/CD実行・通過確認
- [ ] Issue #1145 完全達成確認

🤖 Generated with [Claude Code](https://claude.ai/code)