### PR TITLE
🏗️ Issue #1174 リストパーサー最適化完了: 370行→4ファイル責任分離実現

### DIFF
--- a/kumihan_formatter/parsers/list/__init__.py
+++ b/kumihan_formatter/parsers/list/__init__.py
@@ -3,9 +3,12 @@
 責任分離により以下の構造で分割:
 - list_parser.py: メインクラスとパブリックインターフェース
 - list_handlers.py: リスト処理・分析ロジック
+- list_item_handlers.py: 個別アイテム処理ハンドラ
 - list_utils.py: ユーティリティ関数群
 """
 
 from .list_parser import UnifiedListParser
+from .list_handlers import ListHandler
+from .list_item_handlers import ListItemHandler
 
-__all__ = ["UnifiedListParser"]
+__all__ = ["UnifiedListParser", "ListHandler", "ListItemHandler"]

--- a/kumihan_formatter/parsers/list/list_handlers.py
+++ b/kumihan_formatter/parsers/list/list_handlers.py
@@ -23,6 +23,7 @@ from .list_utils import (
     validate_checklist_format,
     validate_definition_format,
 )
+from .list_item_handlers import ListItemHandler
 
 
 class ListHandler:
@@ -262,109 +263,3 @@ class ListHandler:
             errors.extend(definition_errors)
 
         return errors
-
-
-class ListItemHandler:
-    """個別のリストアイテム処理ハンドラ"""
-
-    def __init__(self) -> None:
-        self.logger = get_logger(__name__)
-
-    def handle_unordered_item(self, line: str) -> Dict[str, Any]:
-        """順序なしリストアイテムの処理"""
-        match = re.match(r"^\s*([-*+])\s+(.+)$", line)
-        if match:
-            marker = match.group(1)
-            content = match.group(2)
-
-            return {
-                "type": "unordered",
-                "marker": marker,
-                "content": content,
-                "indent_level": get_list_nesting_level(line),
-            }
-
-        return {"type": "unknown", "content": line}
-
-    def handle_ordered_numeric_item(self, line: str) -> Dict[str, Any]:
-        """数字順序付きリストアイテムの処理"""
-        match = re.match(r"^\s*(\d+)\.\s+(.+)$", line)
-        if match:
-            number = int(match.group(1))
-            content = match.group(2)
-
-            return {
-                "type": "ordered_numeric",
-                "number": number,
-                "content": content,
-                "indent_level": get_list_nesting_level(line),
-            }
-
-        return {"type": "unknown", "content": line}
-
-    def handle_checklist_item(self, line: str) -> Dict[str, Any]:
-        """チェックリストアイテムの処理"""
-        match = re.match(r"^\s*- \[([x ])\]\s+(.+)$", line)
-        if match:
-            checked = match.group(1) == "x"
-            content = match.group(2)
-
-            return {
-                "type": "checklist",
-                "checked": checked,
-                "content": content,
-                "indent_level": get_list_nesting_level(line),
-            }
-
-        return {"type": "unknown", "content": line}
-
-    def handle_definition_item(self, line: str) -> Dict[str, Any]:
-        """定義リストアイテムの処理"""
-        if line.strip().endswith(":") and not line.startswith(" "):
-            term = line.strip()[:-1]
-
-            return {
-                "type": "definition_term",
-                "term": term,
-                "indent_level": get_list_nesting_level(line),
-            }
-        elif line.startswith((" ", "\t")) and line.strip():
-            return {
-                "type": "definition_content",
-                "content": line.strip(),
-                "indent_level": get_list_nesting_level(line),
-            }
-
-        return {"type": "unknown", "content": line}
-
-    def handle_alpha_item(self, line: str) -> Dict[str, Any]:
-        """アルファベット順序付きリストアイテムの処理"""
-        match = re.match(r"^\s*([a-zA-Z])\.\s+(.+)$", line)
-        if match:
-            letter = match.group(1)
-            content = match.group(2)
-
-            return {
-                "type": "ordered_alpha",
-                "letter": letter,
-                "content": content,
-                "indent_level": get_list_nesting_level(line),
-            }
-
-        return {"type": "unknown", "content": line}
-
-    def handle_roman_item(self, line: str) -> Dict[str, Any]:
-        """ローマ数字順序付きリストアイテムの処理"""
-        match = re.match(r"^\s*([ivxlcdm]+)\.\s+(.+)$", line, re.IGNORECASE)
-        if match:
-            roman = match.group(1)
-            content = match.group(2)
-
-            return {
-                "type": "ordered_roman",
-                "roman": roman,
-                "content": content,
-                "indent_level": get_list_nesting_level(line),
-            }
-
-        return {"type": "unknown", "content": line}

--- a/kumihan_formatter/parsers/list/list_item_handlers.py
+++ b/kumihan_formatter/parsers/list/list_item_handlers.py
@@ -1,0 +1,117 @@
+"""List Item Handlers - 個別リストアイテム処理ハンドラ
+
+分離された責任:
+- 個別リストアイテムの処理
+- 各種マーカー形式のハンドラ（順序なし、数字、チェック、定義、アルファベット、ローマ数字）
+"""
+
+from typing import Any, Dict
+import re
+from ...core.utilities.logger import get_logger
+from .list_utils import get_list_nesting_level
+
+
+class ListItemHandler:
+    """個別のリストアイテム処理ハンドラ"""
+
+    def __init__(self) -> None:
+        self.logger = get_logger(__name__)
+
+    def handle_unordered_item(self, line: str) -> Dict[str, Any]:
+        """順序なしリストアイテムの処理"""
+        match = re.match(r"^\s*([-*+])\s+(.+)$", line)
+        if match:
+            marker = match.group(1)
+            content = match.group(2)
+
+            return {
+                "type": "unordered",
+                "marker": marker,
+                "content": content,
+                "indent_level": get_list_nesting_level(line),
+            }
+
+        return {"type": "unknown", "content": line}
+
+    def handle_ordered_numeric_item(self, line: str) -> Dict[str, Any]:
+        """数字順序付きリストアイテムの処理"""
+        match = re.match(r"^\s*(\d+)\.\s+(.+)$", line)
+        if match:
+            number = int(match.group(1))
+            content = match.group(2)
+
+            return {
+                "type": "ordered_numeric",
+                "number": number,
+                "content": content,
+                "indent_level": get_list_nesting_level(line),
+            }
+
+        return {"type": "unknown", "content": line}
+
+    def handle_checklist_item(self, line: str) -> Dict[str, Any]:
+        """チェックリストアイテムの処理"""
+        match = re.match(r"^\s*- \[([x ])\]\s+(.+)$", line)
+        if match:
+            checked = match.group(1) == "x"
+            content = match.group(2)
+
+            return {
+                "type": "checklist",
+                "checked": checked,
+                "content": content,
+                "indent_level": get_list_nesting_level(line),
+            }
+
+        return {"type": "unknown", "content": line}
+
+    def handle_definition_item(self, line: str) -> Dict[str, Any]:
+        """定義リストアイテムの処理"""
+        if line.strip().endswith(":") and not line.startswith(" "):
+            term = line.strip()[:-1]
+
+            return {
+                "type": "definition_term",
+                "term": term,
+                "indent_level": get_list_nesting_level(line),
+            }
+        elif line.startswith((" ", "\t")) and line.strip():
+            return {
+                "type": "definition_content",
+                "content": line.strip(),
+                "indent_level": get_list_nesting_level(line),
+            }
+
+        return {"type": "unknown", "content": line}
+
+    def handle_alpha_item(self, line: str) -> Dict[str, Any]:
+        """アルファベット順序付きリストアイテムの処理"""
+        match = re.match(r"^\s*([a-zA-Z])\.\s+(.+)$", line)
+        if match:
+            letter = match.group(1)
+            content = match.group(2)
+
+            return {
+                "type": "ordered_alpha",
+                "letter": letter,
+                "content": content,
+                "indent_level": get_list_nesting_level(line),
+            }
+
+        return {"type": "unknown", "content": line}
+
+    def handle_roman_item(self, line: str) -> Dict[str, Any]:
+        """ローマ数字順序付きリストアイテムの処理"""
+        match = re.match(r"^\s*([ivxlcdm]+)\.\s+(.+)$", line, re.IGNORECASE)
+        if match:
+            roman = match.group(1)
+            content = match.group(2)
+
+            return {
+                "type": "ordered_roman",
+                "roman": roman,
+                "content": content,
+                "indent_level": get_list_nesting_level(line),
+            }
+
+        return {"type": "unknown", "content": line}


### PR DESCRIPTION
## 概要
Issue #1174対応として、肥大化したlist_handlers.py（370行）を責任別に最適化し、4ファイル構造に再編成しました。

## 実装内容
- **ListItemHandler分離**: 個別アイテム処理ハンドラを`list_item_handlers.py`として独立
- **ファイルサイズ最適化**: list_handlers.py 370行→265行（目標250-300行達成）
- **責任分離の明確化**: パーサー/ハンドラ/アイテム処理/ユーティリティの4層構造

## 技術的成果
✅ 各ファイル500行以下実現（最大292行）  
✅ 責任分離による保守性向上  
✅ 100%リスト機能維持・テスト通過  
✅ インポート構造とモジュール構成の最適化

## ファイル構造
```
parsers/list/
├── __init__.py (14行) - モジュールエクスポート
├── list_parser.py (275行) - メインクラス・プロトコル実装  
├── list_handlers.py (265行) - リスト処理ロジック
├── list_item_handlers.py (117行) - 個別アイテム処理ハンドラ
└── list_utils.py (292行) - ユーティリティ関数群
```

## テスト結果
リスト関連テストが100%通過、機能完全性を保証

🤖 Generated with [Claude Code](https://claude.ai/code)