### PR TITLE
Chore: Blackフォーマット準拠の微修正

### DIFF
--- a/kumihan_formatter/core/common/processing_errors.py
+++ b/kumihan_formatter/core/common/processing_errors.py
@@ -15,6 +15,7 @@ class ParallelProcessingError(Exception):
     Examples:
         >>> raise ParallelProcessingError("プロセス間でのデータ競合が発生")
     """
+
     pass
 
 
@@ -27,6 +28,7 @@ class ChunkProcessingError(Exception):
     Examples:
         >>> raise ChunkProcessingError("チャンクサイズが制限を超過")
     """
+
     pass
 
 
@@ -39,6 +41,7 @@ class MemoryMonitoringError(Exception):
     Examples:
         >>> raise MemoryMonitoringError("メモリ使用量が制限値250MBを超過")
     """
+
     pass
 
 
@@ -75,7 +78,7 @@ class ExtractionError(Exception):
 
 __all__ = [
     "ParallelProcessingError",
-    "ChunkProcessingError", 
+    "ChunkProcessingError",
     "MemoryMonitoringError",
     "SpecializedParsingError",
     "MarkerValidationError",

--- a/kumihan_formatter/core/types/__init__.py
+++ b/kumihan_formatter/core/types/__init__.py
@@ -12,7 +12,7 @@ __all__ = [
     # 文書型定義
     "DocumentType",
     # 目次型定義
-    "TOCEntry", 
+    "TOCEntry",
     # チャンク型定義（document_types.pyに統合済み）
     "ChunkInfo",
 ]

--- a/kumihan_formatter/core/types/document_types.py
+++ b/kumihan_formatter/core/types/document_types.py
@@ -29,6 +29,7 @@ def get_type_display_names() -> dict[DocumentType, str]:
         DocumentType.GENERAL: "📄 一般文書",
     }
 
+
 # チャンク関連型定義（chunk_types.pyから統合）
 from dataclasses import dataclass
 from typing import List


### PR DESCRIPTION
Blackが指摘した3ファイルの軽微なフォーマット修正のみを実施。\n- processing_errors.py: 末尾スペース除去・空行整備\n- types/__init__.py: 末尾スペース除去\n- types/document_types.py: トップレベル定義の間に空行追加\n\n動作変更はありません。