### PR TITLE
types: specialized_parserのstrictエラー第一次修正

### DIFF
--- a/kumihan_formatter/core/common/processing_errors.py
+++ b/kumihan_formatter/core/common/processing_errors.py
@@ -48,31 +48,37 @@ class MemoryMonitoringError(Exception):
 # パーサー系エラー
 class SpecializedParsingError(Exception):
     """特殊化パーサー固有のエラー"""
+
     pass
 
 
 class MarkerValidationError(Exception):
     """マーカー検証エラー"""
+
     pass
 
 
 class FormatProcessingError(Exception):
     """フォーマット処理エラー"""
+
     pass
 
 
 class ParserUtilsError(Exception):
     """パーサーユーティリティ固有のエラー"""
+
     pass
 
 
 class KeywordValidationError(Exception):
     """キーワード検証エラー"""
+
     pass
 
 
 class ExtractionError(Exception):
     """抽出処理エラー"""
+
     pass
 
 

--- a/kumihan_formatter/parsers/specialized_parser.py
+++ b/kumihan_formatter/parsers/specialized_parser.py
@@ -20,16 +20,11 @@ from .keyword_definitions import KeywordDefinitions
 from .unified_keyword_parser import UnifiedKeywordParser
 
 
-# エラークラスは共通モジュールから使用
-# from kumihan_formatter.core.common.processing_errors import SpecializedParsingError
-
-
-# エラークラスは共通モジュールから使用
-# from kumihan_formatter.core.common.processing_errors import MarkerValidationError
-
-
-# エラークラスは共通モジュールから使用
-# from kumihan_formatter.core.common.processing_errors import FormatProcessingError
+from ..core.common.processing_errors import (
+    SpecializedParsingError,
+    MarkerValidationError,
+    FormatProcessingError,
+)
 
 
 class SpecializedParser:
@@ -148,10 +143,10 @@ class SpecializedParser:
             return Node(
                 type="marker",
                 content=marker_content,
-                decorator=decorator,
-                line_number=1,
-                column=1,
                 attributes={
+                    "decorator": decorator,
+                    "line_number": 1,
+                    "column": 1,
                     "keyword_type": keyword_result.type,
                     "processed_by": "specialized_parser",
                 },
@@ -188,9 +183,9 @@ class SpecializedParser:
             return Node(
                 type="new_format",
                 content=processed_content,
-                line_number=1,
-                column=1,
                 attributes={
+                    "line_number": 1,
+                    "column": 1,
                     "format_data": format_data,
                     "original_formats": matches,
                     "processed_by": "specialized_parser",
@@ -234,9 +229,9 @@ class SpecializedParser:
             return Node(
                 type="ruby_format",
                 content=processed_content,
-                line_number=1,
-                column=1,
                 attributes={
+                    "line_number": 1,
+                    "column": 1,
                     "ruby_data": ruby_data,
                     "processed_by": "specialized_parser",
                 },
@@ -273,9 +268,9 @@ class SpecializedParser:
             return Node(
                 type="inline_format",
                 content=processed_content,
-                line_number=1,
-                column=1,
                 attributes={
+                    "line_number": 1,
+                    "column": 1,
                     "inline_data": inline_data,
                     "processed_by": "specialized_parser",
                 },
@@ -297,9 +292,12 @@ class SpecializedParser:
         return Node(
             type="generic_special",
             content=content,
-            line_number=1,
-            column=1,
-            attributes={"processed_by": "specialized_parser", "format_type": "generic"},
+            attributes={
+                "line_number": 1,
+                "column": 1,
+                "processed_by": "specialized_parser",
+                "format_type": "generic",
+            },
         )
 
     def validate(self, content: str) -> bool:
@@ -328,7 +326,7 @@ class SpecializedParser:
             return False
 
     # プライベートヘルパーメソッド
-    def _init_new_format_patterns(self) -> Dict[str, re.Pattern]:
+    def _init_new_format_patterns(self) -> Dict[str, re.Pattern[str]]:
         """新フォーマットパターン初期化"""
         return {
             "variable": re.compile(r"\$([a-zA-Z_][a-zA-Z0-9_]*)"),
@@ -336,7 +334,7 @@ class SpecializedParser:
             "attribute": re.compile(r"@([a-zA-Z_][a-zA-Z0-9_]*)"),
         }
 
-    def _init_ruby_format_patterns(self) -> Dict[str, re.Pattern]:
+    def _init_ruby_format_patterns(self) -> Dict[str, re.Pattern[str]]:
         """ルビフォーマットパターン初期化"""
         return {
             "kanji": re.compile(r"[\u4e00-\u9faf]+"),
@@ -344,7 +342,7 @@ class SpecializedParser:
             "katakana": re.compile(r"[\u30a1-\u30f6]+"),
         }
 
-    def _init_inline_patterns(self) -> Dict[str, re.Pattern]:
+    def _init_inline_patterns(self) -> Dict[str, re.Pattern[str]]:
         """インラインパターン初期化"""
         return {
             "code": re.compile(r"code:([^`]+)"),
@@ -363,7 +361,8 @@ class SpecializedParser:
                 expr_type = pattern_name
                 match = pattern.search(expression)
                 if match:
-                    data["match_groups"] = match.groups()
+                    groups: List[Any] = list(match.groups())
+                    data["match_groups"] = groups
                 break
 
         data["type"] = expr_type


### PR DESCRIPTION
mypy strictの一部エラーを解消する第一弾です。\n\n変更点\n- 例外クラスのimport整備（processing_errorsから）\n- Node生成時の余計なキーワード引数をattributesに移動\n- re.Pattern[str] の型注釈を付与し、match_groupsをList[Any]として格納\n- Blackに合わせて空行を調整\n\n効果\n- mypyエラー: 35 → 20 に減少（ローカル計測）\n\n残件（別PR予定）\n- core_parserのOptional整合、parser_utilsの比較演算型、parser.pyの戻り値統一、core_managerの注釈整備、sample_commandのrender引数型など。