### PR TITLE
types: mypy strict 第二弾（core_parser/parser_utils 等）

### DIFF
--- a/kumihan_formatter/managers/core_manager.py
+++ b/kumihan_formatter/managers/core_manager.py
@@ -54,9 +54,9 @@ class CoreManager:
         self._template_cache: Dict[str, str] = {}
 
         # 配布管理コンポーネント (遅延初期化)
-        self._distribution_structure = None
-        self._distribution_converter = None
-        self._distribution_processor = None
+        self._distribution_structure: Any | None = None
+        self._distribution_converter: Any | None = None
+        self._distribution_processor: Any | None = None
 
     # ========== ファイルIO機能（旧ResourceManager） ==========
 
@@ -330,7 +330,7 @@ class CoreManager:
 
     # ========== 配布管理機能（DistributionManager統合） ==========
 
-    def _init_distribution_components(self):
+    def _init_distribution_components(self) -> None:
         """配布管理コンポーネントの遅延初期化"""
         if self._distribution_structure is None:
             try:

--- a/kumihan_formatter/parsers/core_parser.py
+++ b/kumihan_formatter/parsers/core_parser.py
@@ -105,7 +105,7 @@ class Parser:
         try:
             from .unified_keyword_parser import UnifiedKeywordParser
 
-            self.keyword_parser = UnifiedKeywordParser()
+            self.keyword_parser: Optional[UnifiedKeywordParser] = UnifiedKeywordParser()
         except ImportError:
             self.logger.warning("UnifiedKeywordParserのインポートに失敗")
             self.keyword_parser = None
@@ -268,8 +268,7 @@ class Parser:
         return Node(
             type="parsed_content",
             content=f"Processed {processed_count} lines",
-            line_number=processed_count,
-            column=1,
+            attributes={"line_number": processed_count, "column": 1},
         )
 
 

--- a/kumihan_formatter/parsers/parser_utils.py
+++ b/kumihan_formatter/parsers/parser_utils.py
@@ -392,8 +392,20 @@ class ParserUtils:
     # プライベートバリデーターメソッド
     def _validate_length(self, keyword: str) -> bool:
         """長さ検証"""
-        min_len = self.validation_rules["min_keyword_length"]
-        max_len = self.validation_rules["max_keyword_length"]
+        raw_min = self.validation_rules.get("min_keyword_length", 1)
+        raw_max = self.validation_rules.get("max_keyword_length", 255)
+        def _to_int(x: Any, default: int) -> int:
+            try:
+                if isinstance(x, (int,)):
+                    return int(x)
+                if isinstance(x, str) and x.isdigit():
+                    return int(x)
+            except Exception:
+                pass
+            return default
+
+        min_len: int = _to_int(raw_min, 1)
+        max_len: int = _to_int(raw_max, 255)
         return min_len <= len(keyword) <= max_len
 
     def _validate_characters(self, keyword: str) -> bool:
@@ -414,7 +426,8 @@ class ParserUtils:
 
     def _validate_reserved(self, keyword: str) -> bool:
         """予約語検証"""
-        return keyword not in self.validation_rules["reserved_keywords"]
+        reserved: set[str] | list[str] = self.validation_rules["reserved_keywords"]  # type: ignore[assignment]
+        return keyword not in set(reserved)
 
     def _validate_structure(self, keyword: str) -> bool:
         """構造検証（追加のルール）"""

--- a/kumihan_formatter/parsers/specialized_parser.py
+++ b/kumihan_formatter/parsers/specialized_parser.py
@@ -353,7 +353,7 @@ class SpecializedParser:
     def _parse_new_format_expression(self, expression: str) -> Dict[str, Any]:
         """新フォーマット式解析"""
         expr_type = "unknown"
-        data = {"expression": expression}
+        data: Dict[str, Any] = {"expression": expression}
 
         # パターン判定
         for pattern_name, pattern in self._new_format_patterns.items():
@@ -362,7 +362,7 @@ class SpecializedParser:
                 match = pattern.search(expression)
                 if match:
                     groups: List[Any] = list(match.groups())
-                    data["match_groups"] = groups
+                    data["match_groups"] = groups  # store as list for JSON safety
                 break
 
         data["type"] = expr_type


### PR DESCRIPTION
mypy strictの残りを大きく削減/解消。\n\n変更点\n- core_parser: Optional整合、Nodeのline/columnはattributesへ\n- parser_utils: ルール値の安全なint化・reserved_keywordsの型扱い見直し\n- parser.py: 例外や想定外戻りをerror_node化して常にNodeを返す\n- core_manager: 遅延初期化プロパティに型注釈、初期化関数に戻り注釈\n- specialized_parser: match_groupsをlist[Any]として保存\n\n検証\n- Black: OK\n- mypy strict: 0件\n\n以降の微調整は親トラッカー(#1273)配下で継続します。