### PR TITLE
feat: SyntaxReporter最小実装 (#1278)

### DIFF
--- a/kumihan_formatter/parsers/parser_utils.py
+++ b/kumihan_formatter/parsers/parser_utils.py
@@ -394,6 +394,7 @@ class ParserUtils:
         """長さ検証"""
         raw_min = self.validation_rules.get("min_keyword_length", 1)
         raw_max = self.validation_rules.get("max_keyword_length", 255)
+
         def _to_int(x: Any, default: int) -> int:
             try:
                 if isinstance(x, (int,)):


### PR DESCRIPTION
最小の構文検証ロジックを実装しました。\n\n- ブロック記法の開始/終了対応チェック（#...# と ##）\n- 未対応の終了(UNMATCHED_BLOCK_END)/未クローズ(UNCLOSED_BLOCK)を検出\n- バッククォート奇数個をWARNINGとして検出\n- 空のキーワード/タブ文字は改善提案（WARNING/INFO）\n- 既存のcommands/check_syntax.py と連携済み（text/json出力）\n\n検証: mypy strict=0 / Black=OK。今後のルール追加は拡張方針に基づき段階対応します。