### PR TITLE
docs: Deprecation Policyを追記（#1279）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,23 @@
 - ラベル: `P0`/`P1`/`P2` を標準化。`scripts/set_issue_priorities.sh` で一括付与可能。
 - PR運用: 最小差分・1Issue=1PR。`scripts/create_minimal_pr.sh` でPR作成、`scripts/pr_merge_and_cleanup.sh` でsquashマージとブランチ掃除。
 - ログ: 自動化ログは `tmp/automation-logs/` に保存（git管理外）。
+
+## Deprecation Policy（段階的廃止方針）
+- 対象（棚卸し）:
+  - core/parsing/markdown_parser.py（Deprecated警告あり）
+  - core/parsing/legacy_parser.py（レガシー互換API）
+  - parsers/parser_utils.py（get_keyword_categories/validate_keyword_legacy のDeprecated）
+  - parsers/specialized_parser.py（parse_marker/new_format/ruby のDeprecated）
+  - parsers/core_parser.py（legacy parse系のDeprecated）
+  - core/syntax/__init__.py / core/ast_nodes/__init__.py（後方互換の再エクスポート）
+  - unified_api.py の DummyParser/DummyRenderer（互換目的）
+
+- フェーズ計画（目安）:
+  - Phase 1（〜2025-09-15）: RuntimeのDeprecationWarningを明示・Doc整備・移行案内
+  - Phase 2（〜2025-10-15）: 後方互換エイリアスを非公開化（内部用に限定）/ import時に一次ブロック可
+  - Phase 3（〜2025-11-30）: レガシーAPIの削除（上記対象の段階削除）
+
+- 運用:
+  - 1 Issue = 1 PR 原則で小分けに削除
+  - 各PRで README/QUICKSTART の参照を追随
+  - 影響範囲（public import）に変更が出る場合は minor version を上げる


### PR DESCRIPTION
#1279 の進行に先立ち、段階的廃止方針をAGENTS.mdに追記しました。\n\n- 対象（棚卸し）: legacy_parser/markdown_parser/compatエイリアス ほか\n- フェーズ: P1=警告とドキュメント、P2=非公開化、P3=削除\n- 運用: 1 Issue=1 PRで小分け、README/QUICKSTART追随、必要に応じてマイナーバージョン更新\n\n以降、各対象ごとに小PRでDeprecatedの明示と削除を段階実施します。