### PR TITLE
deprecate: specialized_parser互換関数の警告付与（Phase 1）

### DIFF
--- a/kumihan_formatter/core/syntax/__init__.py
+++ b/kumihan_formatter/core/syntax/__init__.py
@@ -1,8 +1,11 @@
 """Syntax validation module for Kumihan markup
 
-This module provides comprehensive syntax validation for Kumihan markup files.
-It has been refactored from a single large file into focused modules for
-better maintainability and organization.
+本パッケージは構文検証機能の公開エントリです。後方互換のために
+いくつかの関数を再エクスポートしていますが、将来的に整理予定です。
+
+移行ガイド（Deprecation Policy / #1279）:
+- 旧エイリアスは段階的に非公開化→削除。
+- 公開APIは `SyntaxReporter` と `check_files`/`format_error_report` を利用してください。
 """
 
 # Import main classes and functions for backward compatibility


### PR DESCRIPTION
#1279 Phase 1の一貫対応:\n- specialized_parserの互換関数（parse_marker/new_format/ruby）にDeprecationWarningを付与\n- core/syntax/__init__.py に移行案内を追記（公開APIの明示）\n\n互換は維持。mypy/Black OK。