### PR TITLE
docs: ast_nodes再エクスポートの移行案内（Phase 1）

### DIFF
--- a/kumihan_formatter/core/ast_nodes/__init__.py
+++ b/kumihan_formatter/core/ast_nodes/__init__.py
@@ -1,10 +1,8 @@
-"""AST Node definitions for Kumihan-Formatter
+"""AST Node package
 
-This module contains the Abstract Syntax Tree node definitions
-used throughout the parsing and rendering pipeline.
-
-This package maintains backward compatibility by re-exporting
-all classes and functions from the original ast_nodes.py module.
+本パッケージはASTノード周辺の公開エントリです。後方互換のために
+工場関数・基本クラスを再エクスポートしていますが、今後は各モジュール
+（`.node`, `.factories` 等）からの直接importを推奨します（#1279）。
 """
 
 # Factory functions
@@ -26,6 +24,7 @@ from .factories import (
 
 # Core classes
 from .node import Node
+from .node_builder import NodeBuilder
 
 # Utility functions - temporarily commented out due to import issues
 # from ...core.utilities import (


### PR DESCRIPTION
#1279 Phase 1 対応:\n- core/ast_nodes/__init__.py に移行ガイドを追記（今後は .node / .factories を直接import推奨）\n- __all__ を実体に合わせて整備（NodeBuilder を明示import）\n- 非破壊変更。mypy/Black OK