### PR TITLE
📝 P2: ドキュメント整合性 — カバレッジ閾値とCLI使用法を同期 (#1317)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - Lint: `make lint` / 厳格版: `make lint-strict`。
 - テスト: `make test`（カバレッジ付き）/ `make test-unit` / `make test-integration`。
 - 事前フック: `make pre-commit`（ローカル統合チェック）。
-- 実行例: インストール後は `kumihan --help`。開発中は `python -m kumihan_formatter --help`。
+- 実行例: `kumihan <入力ファイル> [出力ファイル]`／開発中は `python -m kumihan_formatter <入力ファイル> [出力ファイル]`。
 
 ## Coding Style & Naming Conventions
 - フォーマッタ: Black（行長 88）。インデント: 4スペース。
@@ -23,7 +23,7 @@
 ## Testing Guidelines
 - フレームワーク: pytest（`pyproject.toml`に設定）。
 - 実行: `pytest -q` も可。カバレッジは HTML を `tmp/htmlcov/` に出力。
-- しきい値: 現在 `--cov-fail-under=6`（段階的に引き上げ予定）。
+- しきい値: 現在 `--cov-fail-under=20`（段階的に引き上げ予定、#1280/#1307参照）。
 - 命名: ファイルは `test_*.py`、関数は `test_*`。`@pytest.mark.unit|integration|slow|e2e` を適切に付与。
 
 ## Commit & Pull Request Guidelines

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,11 +29,11 @@ with KumihanFormatter() as formatter:
 
 ### CLI使用
 ```bash
-# 基本変換
-kumihan-formatter convert input.kumihan output.html
+# 基本変換（エントリポイントは kumihan）
+kumihan input.kumihan [output.html]
 
-# バッチ処理
-kumihan-formatter convert *.kumihan --output-dir ./html/
+# Pythonモジュールとしての実行
+python -m kumihan_formatter input.kumihan [output.html]
 ```
 
 ---


### PR DESCRIPTION
## 概要
ドキュメント（AGENTS.md/QUICKSTART.md）を実際の設定・実装に同期しました。

## 変更点
- カバレッジ閾値: `--cov-fail-under=20` に更新（pyproject.iniと一致）
- CLI使用法: エントリポイントは `kumihan <入力> [出力]` に統一
  - `kumihan-formatter convert ...` の表記を削除（未実装のため）

## 確認
- `scripts/document_consistency_checker.py check && summary` → `Status: ok` を確認

## 関連
Closes #1317
