### PR TITLE
♻️ P1: 公開API表面積の縮小（Phase 2）— parsers/commands のトップレベル再エクスポート停止 (#1303)

### DIFF
--- a/kumihan_formatter/commands/__init__.py
+++ b/kumihan_formatter/commands/__init__.py
@@ -1,10 +1,10 @@
+"""commands パッケージ（Phase 2: 公開API最小化）
+
+トップレベルでのコマンド再エクスポートは行いません。
+必要な場合は各モジュールから直接 import してください。
+
+例:
+    from kumihan_formatter.commands.check_syntax import main as check_syntax
 """
-変換コマンドモジュール
 
-Issue #1207対応: 技術的負債削除・存在するモジュールのみインポート
-過度なファイル分割による参照エラーを解消
-"""
-
-# Issue #1207: 安全なモジュールのみインポート
-
-__all__ = ["SampleCommand"]
+__all__: list[str] = []

--- a/kumihan_formatter/parsers/__init__.py
+++ b/kumihan_formatter/parsers/__init__.py
@@ -1,75 +1,27 @@
-"""Parser Module - 統合パーサーシステム
+"""parsers パッケージ（Phase 2: 公開API最小化）
 
-Issue #1252対応完了版：10個→5個のParser統合最適化完了
+本パッケージのトップレベル再エクスポートは段階的に廃止しました。
+以降は必要なクラス/関数を各モジュールから直接 import してください。
 
-統合後の5つのコンポーネント:
-1. main_parser.py - メインパーサー（自動判定・振り分け）
-2. core_parser.py - コアパーサー（legacy+parser_core統合）
-3. specialized_parser.py - 特殊化パーサー（マーカー・フォーマット系統合）
-4. parser_protocols.py - プロトコル定義
-5. parser_utils.py - ユーティリティ統合
+例:
+    from kumihan_formatter.parsers.unified_list_parser import UnifiedListParser
+    from kumihan_formatter.parsers.main_parser import MainParser
+
+注記:
+- 互換目的のトップレベル名（Unified* / CoreParser 等）の公開は停止しました。
+- 公開APIは AGENTS.md の「公開API（現時点）」に準拠し、parsers 配下は内部扱いです。
 """
 
+from __future__ import annotations
+
 import warnings
-from typing import Any, Dict, List, Optional, Union
 
-# Issue #1252統合パーサーシステム（最適化版）
-from .main_parser import MainParser
-from .core_parser import Parser as CoreParser, ParallelProcessingConfig
-from .specialized_parser import SpecializedParser
-from .parser_utils import ParserUtils
+__all__: list[str] = []
 
-# 既存統合パーサー（既に最適化済み）
-from .unified_list_parser import UnifiedListParser
-from .unified_keyword_parser import UnifiedKeywordParser
-from .unified_markdown_parser import UnifiedMarkdownParser
-
-# プロトコル・ユーティリティ
-from .parser_protocols import ParserProtocol
-
-__all__ = [
-    # 統合最適化パーサー（Issue #1252）
-    "MainParser",
-    "CoreParser",
-    "SpecializedParser",
-    "ParserUtils",
-    # 設定・プロトコル
-    "ParallelProcessingConfig",
-    "ParserProtocol",
-    # 既存統合パーサー
-    "UnifiedListParser",
-    "UnifiedKeywordParser",
-    "UnifiedMarkdownParser",
-]
-
-
-# 統合パーシング関数（最適化版）
-def parse(
-    content: Union[str, List[str]],
-    parser_type: str = "auto",
-    config: Optional[Dict[str, Any]] = None,
-) -> Optional[Union[Any, Dict[str, Any]]]:
-    """統合パーシング関数（Issue #1252最適化版）
-
-    Args:
-        content: パース対象コンテンツ
-        parser_type: パーサータイプ指定（autoで自動判定）
-        config: パーサー設定
-
-    Returns:
-        パース結果
-
-    Note:
-        10個→5個統合最適化済み
-    """
-    main_parser = MainParser(config)
-    return main_parser.parse(content, parser_type)
-
-
-# Issue #1252完了通知
+# パッケージレベルの import による利用を抑止するため、読み込み時に一度だけ警告します。
 warnings.warn(
-    "Parser integration optimization completed (Issue #1252). "
-    "10 files reduced to 5 files for better maintainability.",
-    UserWarning,
+    "kumihan_formatter.parsers のトップレベル再エクスポートは廃止されました。"
+    "必要なシンボルは各モジュールから直接 import してください (Phase 2).",
+    DeprecationWarning,
     stacklevel=2,
 )

--- a/tests/unit/test_init_modules.py
+++ b/tests/unit/test_init_modules.py
@@ -9,18 +9,26 @@ class TestParsersInit:
     """parsers/__init__.py テスト"""
 
     def test_parsers_init_import(self):
-        """parsers/__init__.py のimportテスト"""
-        from kumihan_formatter.parsers import UnifiedListParser
+        """parsers/__init__.py は再エクスポートしない（Phase 2）"""
+        import importlib
+        import sys
+        import types
+        import pytest
 
-        assert UnifiedListParser is not None
-        assert hasattr(UnifiedListParser, "__init__")
+        # 直接モジュールからのimportは成功する
+        from kumihan_formatter.parsers.unified_list_parser import UnifiedListParser  # noqa: F401
+
+        # トップレベルからの再エクスポートは不可（ImportError想定）
+        with pytest.raises(ImportError):
+            from kumihan_formatter import parsers as _p  # noqa: F401
+            from kumihan_formatter.parsers import UnifiedListParser as _u  # type: ignore # noqa: F401
 
     def test_parsers_init_all(self):
         """parsers/__init__.py の__all__テスト"""
         import kumihan_formatter.parsers as parsers_module
 
         assert hasattr(parsers_module, "__all__")
-        assert "UnifiedListParser" in parsers_module.__all__
+        assert "UnifiedListParser" not in parsers_module.__all__
 
 
 class TestCoreInit:


### PR DESCRIPTION
## 目的
- 後方互換エイリアスの非公開化を継続し、公開APIを最小化（Phase 2）。

## 変更点
- `kumihan_formatter/parsers/__init__.py`
  - トップレベルの再エクスポートを廃止、`__all__ = []`
  - import時に DeprecationWarning（1回）を発行し、直接モジュールからのimportを誘導
- `kumihan_formatter/commands/__init__.py`
  - トップレベル再エクスポート廃止、`__all__ = []`
- `tests/unit/test_init_modules.py`
  - 仕様変更に合わせて、再エクスポート不可（ImportError）であることを検証

## 影響
- リポジトリ内で `from kumihan_formatter.parsers import X` は未使用に変更済み
- 直接モジュール import（例: `parsers.unified_list_parser`）は従来どおり利用可能

## 検証
```bash
make lint
python -m pytest tests/unit/test_init_modules.py --no-cov -q  # 3 passed
```

## 関連
Closes #1303
Refs #1279
