### PR TITLE
📝 refs #1279: README/QUICKSTART に Migration Guide へのリンクを追加

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -94,3 +94,4 @@ result = formatter.convert_text(content)
 - **アーキテクチャ**: ARCHITECTURE.md
 - **開発ガイド**: CLAUDE.md
 - **変更履歴**: CHANGELOG.md
+- **移行ガイド**: docs/DEPRECATION_MIGRATION.md

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Kumihan-Formatter/
 - [CONTRIBUTING.md](./CONTRIBUTING.md)
 - [AGENTS.md](./AGENTS.md)
 - [CHANGELOG.md](./CHANGELOG.md)
+- [Deprecation Migration Guide](./docs/DEPRECATION_MIGRATION.md)
 
 ## 🔧 開発者向け機能
 


### PR DESCRIPTION
利用者が移行先と期日をすぐ参照できるよう、READMEとQUICKSTARTに docs/DEPRECATION_MIGRATION.md を追記しました。