### PR TITLE
📝 Docs: Finalize migration refs & versioning notes (Closes #1279)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,3 +153,4 @@
   - 大規模プロジェクトは索引前提（初回だけ数分）。
   - ツール名は明示指定（クライアントがサーバー名を解決しない場合あり）。
   - ゾンビプロセス対策にWebダッシュボードを有効化可（`serena_config.yml` の `web_dashboard: true`）。
+  - 出力制御は `.serena/memories/serena_tool_output_limits.md` と `docs/SERENA_USAGE.md` を参照（必要ならその場で初期化/再インデックス）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - deprecations: legacy markdown_parser / legacy_parser を削除（Phase 3、#1304/#1305）
 - deprecations: specialized_parser の互換関数（parse_marker / parse_new_format / parse_ruby_format）を撤去（Phase 3、#1306）
 
+### Notes
+- Versioning policy for 0.x: 破壊的変更は Minor バンプで扱います（例: 0.9.x → 0.10.0）。
+- 公開インポート（トップレベル再エクスポート停止）は一部環境で破壊的変更となるため、次回リリースは Minor（0.10.0系）を想定します。詳細は Migration Guide を参照。
+
 ## [2.0.0-enterprise] - 2025-08-19
 
 ### ✨ Added - 新機能

--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ Kumihan-Formatter/
 └── pyproject.toml       # プロジェクト設定
 ```
 
-## Deprecation Notice: DummyParser/DummyRenderer (Phase 1 until 2025-09-15)
-- `kumihan_formatter.unified_api.DummyParser` / `DummyRenderer` are deprecated and will be removed in a later phase.
-- On instantiation, they now emit a DeprecationWarning.
+## Deprecation Notice: DummyParser/DummyRenderer（Phase 1: 〜2025-09-15）
+- `kumihan_formatter.unified_api.DummyParser` / `DummyRenderer` は非推奨です（実行時に DeprecationWarning を出力）。
+- Phase 2（〜2025-10-15）ではトップレベル再エクスポートを停止済み、直接インポートへ移行してください。
+- Phase 3（〜2025-11-30）でレガシーAPIの削除を段階的に進めます。詳細と移行手順は [Deprecation Migration Guide](./docs/DEPRECATION_MIGRATION.md) を参照。
 - Migration examples:
   - Before: `DummyParser().parse(text)` → After: `KumihanFormatter().parse_text(text)`
   - Before: `DummyRenderer().render(node, ctx)` → After: `KumihanFormatter().convert_text(text)`

--- a/docs/SERENA_USAGE.md
+++ b/docs/SERENA_USAGE.md
@@ -1,0 +1,42 @@
+# Serena MCP 使用ガイド（出力制御・失敗回避）
+
+目的: Serenaツール呼び出し時の過大出力による失敗（"The answer is too long ..."）を回避し、安定運用する。
+
+## 既定
+- 検索は狭域から開始し、必要に応じて範囲を広げる。
+- `restrict_search_to_code_files=true` を基本とする。
+- 非コード/生成物は常時除外（`tmp/**`, `output/**`, `htmlcov/**`, `docs/**`, など）。
+- `max_answer_chars` は低め（安全）から。足りなければ段階引き上げ。
+
+## 推奨パラメータ
+- search_for_pattern:
+  - `paths_include_glob="kumihan_formatter/**|tests/**|scripts/**"`
+  - `paths_exclude_glob="tmp/**|output/**|htmlcov/**|docs/**"`
+  - `restrict_search_to_code_files=true`
+  - `max_answer_chars=120000`
+- find_symbol / find_referencing_symbols:
+  - まず `relative_path` を対象ファイル/ディレクトリに限定
+  - `max_answer_chars=90000`
+- get_symbols_overview:
+  - `max_answer_chars=60000`
+- read_file:
+  - 400–600 行単位で分割取得（`start_line`/`end_line`）
+  - `max_answer_chars=120000`
+
+## 再試行手順（順守）
+1. 範囲をさらに絞る（`relative_path`/`paths_include_glob`）。
+2. 検索語を分割して複数回に分ける。
+3. `read_file` は 300–400 行単位に更に細分化。
+4. それでも不足する場合に限り `max_answer_chars` を 1 段階上げる（+30k〜+60k）。
+
+## メモ
+- CLIのシェル出力は 250 行上限。長文は必ず分割。
+- 詳細は `.serena/memories/serena_tool_output_limits.md` を参照。
+
+## 初期化/リセット（ローカル運用前提のメモ）
+- Serenaはローカルで動作するMCPサーバで、プロジェクト配下に `.serena/` ディレクトリ（`project.yml` と `memories/`）を生成し、設定やメモを保存する。
+- リセットは簡単で、以下の流れで初期状態に戻せる:
+  1) MCPクライアント/サーバを停止（例: IDEやデスクトップクライアント）。
+  2) プロジェクトの `.serena/` を削除。
+  3) 必要に応じて再インデックス（例: `uvx --from git+https://github.com/oraios/serena serena index-project`）。
+- SSE常駐などを使う場合は、クライアントからポート指定で再接続すれば良い（設定は通常`.serena/`再生成時に復元される）。


### PR DESCRIPTION
目的: Issue #1279 の残タスク（README/AGENTSの棚卸し・Migration Guideリンク・バージョニング方針追記）を反映。\n\n変更点:\n- READMEのDeprecation章を最新化（Phase日付とリンク）\n- CHANGELOG Unreleasedに0.xのバージョニング方針（破壊的変更=Minorバンプ）を追記\n- docs/SERENA_USAGE.mdに初期化/リセットメモを追記（運用ドキュメント整合）\n\n注意: リリース作業は含まず。テストは既存失敗があるため本PRでは対象外。CI要件なし・最小差分方針。\n\nCloses #1279