### PR TITLE
📝 Docs: Sync CLI/API usage and remove legacy references (Closes #1335)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@
 ## Testing Guidelines
 - フレームワーク: pytest（`pyproject.toml`に設定）。
 - 実行: `pytest -q` も可。カバレッジは HTML を `tmp/htmlcov/` に出力。
-- しきい値: 現在 `--cov-fail-under=20`（段階的に引き上げ予定、#1280/#1307参照）。
+- しきい値: 現在 `--cov-fail-under=30`（段階的に引き上げ予定、#1280/#1307参照）。
 - 命名: ファイルは `test_*.py`、関数は `test_*`。`@pytest.mark.unit|integration|slow|e2e` を適切に付与。
 
 ## Commit & Pull Request Guidelines

--- a/API.md
+++ b/API.md
@@ -40,43 +40,30 @@ self.main_renderer = MainRenderer(config)         # 統合レンダラー
 
 ---
 
-## 📋 主要パーサー
+## 📋 解析API（現行）
 
-### SimpleKumihanParser
+### 推奨: KumihanFormatter 経由
 ```python
-from kumihan_formatter.simple_parser import SimpleKumihanParser
+from kumihan_formatter.unified_api import KumihanFormatter
 
-parser = SimpleKumihanParser()
-result = parser.parse(text)  # ParseResult返却
+formatter = KumihanFormatter()
+parsed = formatter.parse_text(text)  # Dict[str, Any]
 ```
 
-**対応記法**:
-- ブロック記法: `# 装飾 #内容##`
-- 見出し記法: `# 見出し1 #タイトル##`
-- リスト記法: `-` `1.` 記法
-- インライン記法: 太字・イタリック
-
-### 統合パーサー群
+### 代替: Parserファサード
 ```python
-# 自動選択 (推奨)
-result = unified_parse(content, "auto")
-
-# 個別指定
-result = unified_parse(content, "content")  # ContentParser
-result = unified_parse(content, "block")    # BlockParser
-result = unified_parse(content, "list")     # ListParser
+from kumihan_formatter.parser import parse
+node = parse(text)  # core.ast_nodes.Node
 ```
 
 ---
 
-## 🎨 主要レンダラー
-
-### SimpleHTMLRenderer
+## 🎨 レンダリングAPI（現行）
 ```python
-from kumihan_formatter.simple_renderer import SimpleHTMLRenderer
+from kumihan_formatter.unified_api import KumihanFormatter
 
-renderer = SimpleHTMLRenderer()
-html = renderer.render(parse_result)  # HTML出力
+formatter = KumihanFormatter()
+html = formatter.convert_text(text)  # str (HTML)
 ```
 
 **出力特徴**:
@@ -104,16 +91,15 @@ print(info['version'], info['parsers'])
 
 ### エラーハンドリング
 ```python
+from kumihan_formatter.unified_api import KumihanFormatter
+
+formatter = KumihanFormatter()
 try:
-    result = formatter.convert_text(text)
-    if result.success:
-        print("変換成功:", result.html)
-    else:
-        print("変換エラー:", result.errors)
-except KumihanSyntaxError as e:
-    print("構文エラー:", e.message)
-except KumihanProcessingError as e:
-    print("処理エラー:", e.details)
+    html = formatter.convert_text(text)
+    print("変換成功")
+except Exception as e:
+    # 現行APIは標準例外で通知（専用例外は将来導入予定）
+    print("変換エラー:", e)
 ```
 
 ---

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,15 +7,13 @@
 
 ## 🏗️ 全体アーキテクチャ
 
-### 3層アーキテクチャ
+### 構成概要
 ```
 kumihan_formatter/
 ├── 🎯 unified_api.py        # 統合エントリーポイント
-├── 📝 simple_parser.py      # 軽量パーサー (96%カバレッジ)
-├── 🎨 simple_renderer.py    # 軽量レンダラー (95%カバレッジ)
-├── core/                    # コア機能群
-├── parsers/                 # パーサー統合群
-└── rendering/               # レンダリング群
+├── core/                    # コア機能群（api/ rendering/ utilities/ など）
+├── parsers/                 # パーサー群（unified_markdown_parser 等）
+└── ui/ / managers/          # UI補助・マネージャ群
 ```
 
 ### 統合設計思想
@@ -43,34 +41,11 @@ class KumihanFormatter:
 - 設定・状態管理
 - エラー統合処理
 
-### 2. SimpleParser (simple_parser.py)
-```python
-class SimpleKumihanParser:
-    """軽量パーサー - 169行, 96%カバレッジ"""
-    - ブロック記法解析
-    - 見出し記法処理
-    - リスト記法処理
-    - インライン記法処理
-```
+### 2. MainParser（parsers/main_parser.py）
+- 統合パーサー。入力テキストを解析し、内部ノード（Node）へ変換。
 
-**責任**:
-- Kumihan記法 → AST変換
-- 構文検証・エラー報告
-- パフォーマンス最適化
-
-### 3. SimpleRenderer (simple_renderer.py)
-```python
-class SimpleHTMLRenderer:
-    """軽量レンダラー - 62行, 95%カバレッジ"""
-    - HTML生成・出力
-    - CSS統合・スタイリング
-    - テンプレート適用
-```
-
-**責任**:
-- AST → HTML変換
-- スタイル適用・最適化
-- 出力フォーマット制御
+### 3. MainRenderer（core/rendering/main_renderer.py）
+- 解析結果（Dict/Node）からHTMLを組み立てる統合レンダラー。
 
 ---
 
@@ -87,24 +62,9 @@ class SimpleHTMLRenderer:
 📄 出力ファイル
 ```
 
-### データ構造
-```python
-# ParseResult
-@dataclass
-class ParseResult:
-    elements: List[Element]
-    success: bool
-    errors: List[str]
-    metadata: Dict[str, Any]
-
-# Element (AST Node)  
-@dataclass
-class Element:
-    type: str           # "heading", "paragraph", "block"
-    content: str
-    attributes: Dict[str, Any]
-    children: List[Element]
-```
+### データ構造（概要）
+- 解析結果は内部ノード（`core.ast_nodes.Node`）または辞書（Dict）で扱われます。
+  公開API（`KumihanFormatter`）経由ではDict形式を基本とし、レンダラーがHTML文字列を生成します。
 
 ---
 
@@ -166,13 +126,13 @@ rendering/
 ### 品質保証システム
 ```python
 # バリデーション
-core/validation_*.py
+core/validation/
 - 構文検証
 - データ整合性チェック
 - パフォーマンス監視
 
 # ログ・監視
-core/logger.py
+core/utilities/logger.py
 - 構造化ログ
 - パフォーマンス計測
 - エラー追跡
@@ -180,15 +140,7 @@ core/logger.py
 
 ### エラーハンドリング
 ```python
-# カスタム例外
-class KumihanSyntaxError(Exception):
-    """構文エラー専用"""
-
-class KumihanProcessingError(Exception):
-    """処理エラー専用"""
-
-class KumihanFileError(Exception):
-    """ファイル操作エラー専用"""
+※ 現行実装では専用例外は未導入。標準例外で通知（将来導入を検討）。
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ make test-unit  # 単体テストのみ（超高速）
 - **作業期間制限**: 1週間以内（最大10日）
 - **命名規則**: `{type}/issue-{番号}-{英語概要}`
 - **統合頻度**: 3日ごとに統合推奨
-- **自動化**: GitHub Actions連携によるブランチ監視
+- **自動化**: ローカル運用（Makefile + pre-commit）を基本にブランチを管理（GitHub Actionsの追加は前提としない）
 - **設定ファイル**: `.github/quality/branch_strategy.yml`
 
 ### 技術的負債管理システム

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,13 +19,12 @@ cd Kumihan-Formatter
 
 # Python依存関係インストール
 python3 -m pip install -e .
-python3 -m pip install -r requirements-dev.txt
 
-# または一括インストール
+# 開発用一括インストール（推奨）
 python3 -m pip install -e ".[dev]"
 
-# Git hooks セットアップ（必須）
-./scripts/install-hooks.sh
+# pre-commit 相当のローカル統合チェック（フック導入は任意）
+make pre-commit
 ```
 
 ## ブランチ戦略
@@ -76,7 +75,7 @@ pytest
 | **主要README** | `README.md`, `CHANGELOG.md`, `CONTRIBUTING.md` | プロジェクトの顔となる文書 |
 | **Claude関連** | `CLAUDE.md`, `.claude_md_*` | Claude Code用設定 |
 | **ビルドツール** | `Makefile` | 開発コマンドの集約 |
-| **起動スクリプト** | `start-claude-with-serena.sh`, `setup-claude-alias.sh` | プロジェクト全体の起動用 |
+| **開発スクリプト** | `scripts/*.sh`, `scripts/*.py` | プロジェクトの各種ユーティリティ |
 | **Linter設定** | `.markdownlint.json` | ツールがルートを参照 |
 
 ### 🚫 ルートディレクトリに配置してはいけないファイル

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -17,7 +17,8 @@ pip install -e .
 ### 基本的な使い方
 ```python
 # 統合API使用 (推奨)
-from kumihan_formatter.unified_api import KumihanFormatter, quick_convert
+from kumihan_formatter.unified_api import KumihanFormatter
+from kumihan_formatter.core.utilities.api_utils import quick_convert
 
 # 簡単変換
 result = quick_convert("input.kumihan")

--- a/README.md
+++ b/README.md
@@ -179,12 +179,12 @@ Kumihan-Formatter/
 
 ## 🔧 開発者向け機能
 
-### デバッグ機能
-CLIツールで問題が発生した場合、詳細なデバッグ機能を利用できます：
+### デバッグ
+CLIはサブコマンド無しのシンプル構成です（convert等は未提供）。
 
 ```bash
-# CLI開発ログ
-KUMIHAN_DEV_LOG=true kumihan convert input.txt output.txt
+# 基本形式（サブコマンドなし）
+kumihan input.txt [output.html]
 ```
 
 


### PR DESCRIPTION
目的: ドキュメントと実装の不一致を解消し、利用者の混乱を防止。\n\n主な修正:\n- README: サブコマンド表記とKUMIHAN_DEV_LOGを削除。基本形式に統一\n- QUICKSTART: quick_convert import 先を api_utils へ修正\n- API.md: 現行APIに沿った解析/レンダリング例・エラーハンドリングへ刷新\n- ARCHITECTURE.md: simple_* 記載の撤去、主要コンポーネントとパス更新\n- CONTRIBUTING: requirements-dev.txt / install-hooks.sh の参照削除、make pre-commit に統一\n- CLAUDE.md: 自動化の前提をローカル運用へ修正\n- AGENTS.md: カバレッジしきい値を30%に整合\n\n影響範囲: ドキュメントのみ（コード/テスト変更なし）。\n\nCloses #1335