### PR TITLE
♻️ Refactor: Extract parser_utils helpers to utils/ (Closes #1340)

### DIFF
--- a/kumihan_formatter/parsers/utils/__init__.py
+++ b/kumihan_formatter/parsers/utils/__init__.py
@@ -1,0 +1,28 @@
+"""Parsers utility subpackage.
+
+This namespace provides small focused helpers and default data used by
+`parser_utils.ParserUtils`. Public re-exports are intentionally minimal.
+"""
+
+from .keyword_data import (
+    DEFAULT_KEYWORD_CONFIG,
+    DEFAULT_VALIDATION_RULES,
+    DEFAULT_EXTRACTION_CONFIG,
+)
+from .patterns import (
+    build_keyword_patterns,
+    build_validation_patterns,
+    build_utility_patterns,
+)
+from .normalization_utils import normalize_with_patterns
+
+__all__ = [
+    "DEFAULT_KEYWORD_CONFIG",
+    "DEFAULT_VALIDATION_RULES",
+    "DEFAULT_EXTRACTION_CONFIG",
+    "build_keyword_patterns",
+    "build_validation_patterns",
+    "build_utility_patterns",
+    "normalize_with_patterns",
+]
+

--- a/kumihan_formatter/parsers/utils/keyword_data.py
+++ b/kumihan_formatter/parsers/utils/keyword_data.py
@@ -1,0 +1,81 @@
+"""Default keyword/extraction/validation data for ParserUtils.
+
+Keeping default dictionaries in a dedicated module reduces the footprint of
+parser_utils.py and avoids accidental mutation across imports.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Set, Any
+
+
+DEFAULT_KEYWORD_CONFIG: Dict[str, Set[str]] = {
+    "basic_keywords": {
+        "太字",
+        "イタリック",
+        "見出し1",
+        "見出し2",
+        "見出し3",
+        "リスト",
+        "番号リスト",
+        "引用",
+        "コード",
+        "リンク",
+    },
+    "advanced_keywords": {
+        "テーブル",
+        "画像",
+        "注釈",
+        "脚注",
+        "数式",
+        "図表",
+        "キャプション",
+        "参照",
+        "索引",
+    },
+    "formatting_keywords": {
+        "中央",
+        "右寄せ",
+        "左寄せ",
+        "両端揃え",
+        "色",
+        "背景色",
+        "フォント",
+        "サイズ",
+    },
+    "structural_keywords": {
+        "章",
+        "節",
+        "項",
+        "段落",
+        "改ページ",
+        "セクション",
+        "ブロック",
+        "コンテナ",
+    },
+}
+
+
+DEFAULT_VALIDATION_RULES: Dict[str, Any] = {
+    "min_keyword_length": 1,
+    "max_keyword_length": 20,
+    "allow_numbers": True,
+    "allow_special_chars": False,
+    "reserved_keywords": {"エラー", "無効", "不明"},
+}
+
+
+DEFAULT_EXTRACTION_CONFIG: Dict[str, Any] = {
+    "max_extraction_depth": 10,
+    "enable_nested_extraction": True,
+    "preserve_whitespace": False,
+    "case_sensitive": True,
+}
+
+
+__all__ = [
+    "DEFAULT_KEYWORD_CONFIG",
+    "DEFAULT_VALIDATION_RULES",
+    "DEFAULT_EXTRACTION_CONFIG",
+]
+

--- a/kumihan_formatter/parsers/utils/normalization_utils.py
+++ b/kumihan_formatter/parsers/utils/normalization_utils.py
@@ -1,0 +1,22 @@
+"""Normalization helpers for textual content.
+
+Separated to keep ParserUtils focused on orchestration.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Pattern
+
+
+def normalize_with_patterns(text: str, utility_patterns: Dict[str, Pattern[str]]) -> str:
+    if not text:
+        return ""
+
+    normalized = utility_patterns["line_break"].sub("\n", text)
+    normalized = utility_patterns["whitespace"].sub(" ", normalized)
+    normalized = utility_patterns["tab"].sub("    ", normalized)
+    return normalized.strip()
+
+
+__all__ = ["normalize_with_patterns"]
+

--- a/kumihan_formatter/parsers/utils/patterns.py
+++ b/kumihan_formatter/parsers/utils/patterns.py
@@ -1,0 +1,48 @@
+"""Regex pattern builders used by ParserUtils.
+
+Functions return new dictionaries each call to avoid cross-instance sharing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Pattern
+
+
+def build_keyword_patterns() -> Dict[str, Pattern[str]]:
+    return {
+        "basic": re.compile(r"[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]+"),
+        "compound": re.compile(
+            r"[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf][\w\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]*"
+        ),
+        "numeric": re.compile(r"\d+[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]*"),
+        "special": re.compile(
+            r"[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf][\w\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\-_]*"
+        ),
+    }
+
+
+def build_validation_patterns() -> Dict[str, Pattern[str]]:
+    return {
+        "valid_chars": re.compile(r"^[a-zA-Z\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf\d\-_]*$"),
+        "invalid_start": re.compile(r"^[\d\-_]"),
+        "invalid_end": re.compile(r"[\-_]$"),
+        "consecutive_special": re.compile(r"[\-_]{2,}"),
+    }
+
+
+def build_utility_patterns() -> Dict[str, Pattern[str]]:
+    return {
+        "whitespace": re.compile(r"\s+"),
+        "line_break": re.compile(r"\r?\n"),
+        "tab": re.compile(r"\t+"),
+        "punctuation": re.compile(r"[^\w\s\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]"),
+    }
+
+
+__all__ = [
+    "build_keyword_patterns",
+    "build_validation_patterns",
+    "build_utility_patterns",
+]
+


### PR DESCRIPTION
目的: parser_utils.py(526行)の責務を縮小し、データ/正規化/パターン生成を utils/ に切り出し。\n\n変更点:\n- 新規: parsers/utils/{keyword_data.py, patterns.py, normalization_utils.py, __init__.py}\n- 変更: parser_utils は既定データ・パターン・正規化処理を上記へ委譲（互換維持）\n\nふるまい: 既存API/テストは互換。mypy strict 合格。\n\n次段: 検証/抽出のヘルパー分離を別PRで対応。\n\nCloses #1340