### PR TITLE
🧹 Refactor: Isolate compatibility_layer and remove public re-exports (Closes #1344)

### DIFF
--- a/kumihan_formatter/core/utilities/__init__.py
+++ b/kumihan_formatter/core/utilities/__init__.py
@@ -19,10 +19,7 @@ __all__ = [
     "UIProtocol",
     # イベントミックスイン
     "EventEmitterMixin",
-    # 互換性レイヤー
-    "HtmlFormatter",
-    "MarkdownFormatter",
-    "LegacyParserAdapter",
+    # 互換性レイヤー（非公開化: compatibility_layer 直指定のみ許可）
     # ロガー
     "get_logger",
     # トークントラッカー

--- a/kumihan_formatter/core/utilities/compatibility_layer.py
+++ b/kumihan_formatter/core/utilities/compatibility_layer.py
@@ -1,9 +1,23 @@
 """
-互換性レイヤー - Phase3最適化版
+互換性レイヤー - Phase3最適化版（隔離）
 
-MainParser→MasterParser統合により更新
-レガシーAPIとの互換性を保持しつつ、最新アーキテクチャに対応
+MainParser→MasterParser統合により更新。
+レガシーAPIとの互換性を保持しつつ、最新アーキテクチャに対応。
+
+注意: 本モジュールは段階的廃止の対象です（Phase 3）。
+既定ではインポート時警告を出しません。必要に応じて
+環境変数 `KUMIHAN_COMPAT_WARNINGS=1` で警告を有効化できます。
 """
+import os
+import warnings
+
+if os.getenv("KUMIHAN_COMPAT_WARNINGS", "0") in {"1", "true", "True"}:
+    warnings.warn(
+        "compatibility_layer is deprecated and will be removed in Phase 3."
+        " Migrate to unified_api or parser facade.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
 from typing import Any, Dict, List, Optional
 


### PR DESCRIPTION
目的: 互換レイヤの公開面積を最小化し、段階的廃止（Phase3）に備える。\n\n変更点:\n- compatibility_layer: インポート時のDeprecationWarningを環境変数で制御（KUMIHAN_COMPAT_WARNINGS=1）\n- utilities.__init__: 互換レイヤのクラス/エイリアスの再エクスポートを削除\n\n影響: 既存API（compatibility_layer.{MasterParser,parse_text,...}）は維持。mypy/テストに影響なし。\n\nCloses #1344