### PR TITLE
🧪 Tests: Add basic keyword extractor/validator tests

### DIFF
--- a/tests/unit/test_keyword_extractor_basic.py
+++ b/tests/unit/test_keyword_extractor_basic.py
@@ -1,0 +1,26 @@
+"""KeywordExtractor の基本動作テスト"""
+
+from kumihan_formatter.parsers.keyword_extractors import KeywordExtractor
+
+
+def test_extract_inline_format():
+    ex = KeywordExtractor()
+    info = ex.extract_keyword_info("# bold italic # Content text ##")
+
+    assert info is not None
+    assert info["format"] == "inline"
+    assert info["content"] == "Content text"
+    assert "bold" in info["keywords"]
+    assert "italic" in info["keywords"]
+
+
+def test_extract_multiline_format():
+    ex = KeywordExtractor()
+    text = "# bold #\nfirst line\nsecond line\n##\ntrailing"
+    info = ex.extract_keyword_info(text)
+
+    assert info is not None
+    assert info["format"] == "multiline"
+    assert info["content"] == "first line\nsecond line"
+    assert info["keywords"] == ["bold"]
+

--- a/tests/unit/test_keyword_validation_basic.py
+++ b/tests/unit/test_keyword_validation_basic.py
@@ -1,0 +1,24 @@
+"""KeywordValidator の基本動作テスト"""
+
+from kumihan_formatter.parsers.keyword_config import KeywordParserConfig
+from kumihan_formatter.parsers.keyword_validation import KeywordValidator
+
+
+def test_validate_empty_content_is_ok():
+    cfg = KeywordParserConfig()
+    v = KeywordValidator(cfg)
+    assert v.validate("") == []
+
+
+def test_validate_keyword_cache_and_custom():
+    cfg = KeywordParserConfig()
+    v = KeywordValidator(cfg)
+
+    # 既定のカスタムハンドラに登録済みのキーワード
+    assert v.validate_keyword("custom") is True
+    # 未登録
+    assert v.validate_keyword("unknown") is False
+
+    # キャッシュにより2回目も安定
+    assert v.validate_keyword("custom") is True
+


### PR DESCRIPTION
目的: keyword_* 周りのスモールテストを追加し、基本動作と将来拡張の土台を整備。\n- tests/unit/test_keyword_extractor_basic.py\n- tests/unit/test_keyword_validation_basic.py\n\n影響: 既存カバレッジをわずかに底上げ。機能変更なし。