### PR TITLE
🧹 Chore #1362: runtime deps minimalization + extras[cli] + setup update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ help:
 # 基本セットアップ
 setup:
 	@echo "🚀 開発環境セットアップ中..."
-	$(PIP) install -e ".[dev,test,performance,telemetry]"
+	$(PIP) install -e ".[dev,test,performance,telemetry,cli]"
 	@echo "✅ セットアップ完了"
 
 # 総合品質チェック（Issue #1239のメイン機能）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
 ]
+# P1: runtime最小化（未使用依存を削除）
 dependencies = [
-    "jinja2>=3.0",
-    "pyyaml>=6.0",
-    "pydantic>=2.0",
-    "toml>=0.10",
-    "tomli>=1.2.0",
 ]
 
 [project.scripts]
@@ -41,6 +37,11 @@ dev = [
 ]
 performance = [
     "psutil>=5.9",  # メモリ使用量追跡用
+]
+cli = [
+    "watchdog>=4.0",
+    "rich>=13.0",
+    "click>=8.0",
 ]
 telemetry = [
     "opentelemetry-api>=1.20.0",


### PR DESCRIPTION
P1: ランタイム依存を最小化し、CLI関連を extras に分離しました。

- 変更点:
  - [project.dependencies]: 空に（未使用の jinja2/pydantic/pyyaml/toml/tomli を削除）
  - [project.optional-dependencies.cli]: watchdog, rich, click を追加
  - Makefile `make setup`: .[dev,test,performance,telemetry,cli] をインストール
- 目的: 実行時フットプリント削減と依存の役割分離
- 検証: `make quality-check` 成功
- 影響: CLI/開発環境では extras により機能維持