### PR TITLE
✨ Feat #1365: minimal TOCGenerator implementation

### DIFF
--- a/kumihan_formatter/core/rendering/toc_generator.py
+++ b/kumihan_formatter/core/rendering/toc_generator.py
@@ -9,11 +9,8 @@ import re
 
 from ..ast_nodes import Node
 
-# Re-export for compatibility
-# TODO: toc_generator_main.pyが存在しないため一時コメントアウト - Issue #1227対応
-# from .toc_generator_main import TOCGenerator
-
-__all__: list[str] = ["TOCEntry"]  # TOCGeneratorは実装待ち - Issue #1227対応
+# 互換エクスポート
+__all__: list[str] = ["TOCEntry", "TOCGenerator"]
 
 
 class TOCEntry:
@@ -50,3 +47,52 @@ class TOCEntry:
         # Remove any HTML tags from title
         clean_title = re.sub(r"<[^>]+>", "", self.title)
         return clean_title.strip()
+
+
+class TOCGenerator:
+    """Minimal TOC generator (P1)
+
+    入力ノード列から h1〜h5 の見出しを抽出し、階層化した TOCEntry ツリーを構築する。
+    """
+
+    SUPPORTED = {"h1", "h2", "h3", "h4", "h5"}
+
+    def generate_from_nodes(self, nodes: list[Node]) -> list[TOCEntry]:
+        stack: list[TOCEntry] = []
+        roots: list[TOCEntry] = []
+
+        for n in nodes:
+            # ノードのレベル判定（type または tag）
+            t = getattr(n, "type", None)
+            tag = getattr(n, "tag", None)
+            heading = None
+            if isinstance(t, str) and t in self.SUPPORTED:
+                heading = t
+            elif isinstance(tag, str) and tag.lower() in self.SUPPORTED:
+                heading = tag.lower()
+            if not heading:
+                continue
+
+            level = int(heading[1])
+            title = (
+                getattr(n, "content", "")
+                if isinstance(getattr(n, "content", ""), str)
+                else str(getattr(n, "content", ""))
+            )
+            entry = TOCEntry(
+                level=level,
+                title=title,
+                heading_id=f"h-{len(roots)+len(stack)+1}",
+                node=n,
+            )
+
+            # スタックをレベルに合わせて調整
+            while stack and stack[-1].level >= level:
+                stack.pop()
+            if stack:
+                stack[-1].add_child(entry)
+            else:
+                roots.append(entry)
+            stack.append(entry)
+
+        return roots


### PR DESCRIPTION
P1: `TOCGenerator` の最小実装を追加し、h1〜h5 の見出しから階層化した TOC を構築します。

- 実装: `toc_generator.py` に `TOCGenerator.generate_from_nodes(nodes)`
- 互換: 既存 `TOCEntry` を維持、`__all__` で両方を公開
- 検証: mypy/Black/単体テストOK（リグレッションなし）