### PR TITLE
📝 Docs: CHANGELOG/CONTRIBUTING 更新（cov>=45%・Codex運用）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CLI: `--help` / `--version` の実装（argparse化）。
+- 安全ガード: `--dry-run` / `--force` と `KUMIHAN_FORCE` を追加（破壊的操作の抑止）。
+- テスト: ユニットテストを多数追加し、カバレッジ閾値を 45% に引き上げ。
+- ドキュメント: README/QUICKSTART/CONTRIBUTING をCodex運用と安全ガードに合わせて更新。
+
+### Changed
+- 依存関係: ランタイム依存を最小化し、CLI機能を `extras[cli]` に分離（watchdog/rich/click）。
+- 出力ポリシー: `tmp/` 強制を撤廃し、指定パスを尊重する挙動に変更。
+
+### Removed
+- CLAUDE関連: `CLAUDE.md`、関連Makeターゲットと参照を削除。開発運用をCodexに統一。
+
+
+### Added
 - tests: console_ui の軽量ユニットテストを追加（#1308）
 - docs: Deprecation Migration Guide を追加（docs/DEPRECATION_MIGRATION.md、#1309）
 - docs: 例外ポリシー設計（docs/EXCEPTION_POLICY.md、PR #1356）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,13 @@ PRレビュー時は以下を確認：
 
 ## テスト
 
+### テストポリシー（2025-09 時点）
+- カバレッジ閾値: `--cov-fail-under=45`（`pyproject.toml`に準拠）。段階的に引き上げます。
+- 破壊的操作は既定で禁止。必要な網羅は `--dry-run` または `KUMIHAN_FORCE=1` を用いて安全に行うこと。
+- 実ファイル書き込みが必要な場合は `tmp_path` 等の一時ディレクトリを使用し、リポジトリ直下に生成しないこと。
+- CLIテストは `kumihan --help/--version` と `--dry-run/--force` を中心にスモークする（副作用なし）。
+- 型チェックは `mypy --strict` を準拠。オプショナル依存（`watchdog`, `rich`等）は `pyproject.toml` の overrides で missing imports を無効化済み。
+
 ### テストの実行
 ```bash
 # 全テスト実行


### PR DESCRIPTION
Unreleasedに今回の変更を追記し、テスト方針（fail-under=45%・安全ガードの指針）をCONTRIBUTINGに追加。